### PR TITLE
ProjectSelectorを閉じたときにフォルダアイコンが中央からずれる問題を修正

### DIFF
--- a/apps/web/src/components/layout/ProjectSelector/ProjectSelector.module.scss
+++ b/apps/web/src/components/layout/ProjectSelector/ProjectSelector.module.scss
@@ -10,6 +10,11 @@
 	cursor: pointer;
 	color: var(--gray-11);
 	transition: background-color 0.15s ease;
+	justify-content: flex-start;
+
+	&.collapsed {
+		justify-content: center;
+	}
 
 	&:hover {
 		background-color: var(--gray-a4);

--- a/apps/web/src/components/layout/ProjectSelector/ProjectSelector.tsx
+++ b/apps/web/src/components/layout/ProjectSelector/ProjectSelector.tsx
@@ -63,7 +63,10 @@ export function ProjectSelector({
 	};
 
 	const trigger = (
-		<button type="button" className={styles.trigger}>
+		<button
+			type="button"
+			className={`${styles.trigger} ${collapsed ? styles.collapsed : ""}`}
+		>
 			<span className={styles.icon}>
 				{selectedProject ? (
 					<Avatar size={26} name={selectedProject.name} variant="beam" />


### PR DESCRIPTION
# 修正前
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/a6000884-fc3a-4cca-bdea-60aac455fc75" />


# 修正後
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d9c628c8-3ced-48a5-bbe3-69026a3447d5" />
