### PR TITLE
ロールスイッチと実委人側メンバー管理のメニューについて権限に応じて非表示にする

### DIFF
--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -8,8 +8,9 @@ import {
 	IconSettings,
 } from "@tabler/icons-react";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { IconButton } from "@/components/primitives";
+import { listCommitteeMemberPermissions } from "@/lib/api/committee-member";
 import { useAuthStore } from "@/lib/auth";
 import styles from "./Sidebar.module.scss";
 
@@ -43,7 +44,8 @@ const commonItems: MenuItem[] = [
 
 function getRoleSwitchItem(
 	pathname: string,
-	menuItems: MenuItem[]
+	menuItems: MenuItem[],
+	isCommitteeMember: boolean
 ): MenuItem | null {
 	// menuItems のパスからどのロールか判定（/settings 等でも正しく動作）
 	const hasProjectMenu = menuItems.some(item => item.to.startsWith("/project"));
@@ -55,6 +57,8 @@ function getRoleSwitchItem(
 		pathname.startsWith("/project") ||
 		(!pathname.startsWith("/committee") && hasProjectMenu)
 	) {
+		if (!isCommitteeMember) return null;
+
 		return {
 			label: "実委人に切り替え",
 			icon: <IconArrowsExchange size={18} />,
@@ -82,17 +86,62 @@ export function Sidebar({
 }: SidebarProps) {
 	const { location } = useRouterState();
 	const navigate = useNavigate();
-	const { signOut } = useAuthStore();
+	const { committeeMember, isCommitteeMember, signOut } = useAuthStore();
+	const [hasMemberEditPermission, setHasMemberEditPermission] = useState<
+		boolean | null
+	>(null);
+	const shouldCheckMemberEdit = menuItems.some(
+		item => item.to === "/committee/members"
+	);
 
 	const handleSignOut = async () => {
 		await signOut();
 		navigate({ to: "/auth/login" });
 	};
 
-	const roleSwitchItem = getRoleSwitchItem(location.pathname, menuItems);
+	useEffect(() => {
+		if (!shouldCheckMemberEdit || !committeeMember?.id) {
+			setHasMemberEditPermission(null);
+			return;
+		}
+
+		let cancelled = false;
+
+		const loadPermissions = async () => {
+			try {
+				const res = await listCommitteeMemberPermissions(committeeMember.id);
+				if (!cancelled) {
+					setHasMemberEditPermission(
+						res.permissions.some(p => p.permission === "MEMBER_EDIT")
+					);
+				}
+			} catch {
+				// 判定不能な場合は現状維持で表示する
+				if (!cancelled) {
+					setHasMemberEditPermission(null);
+				}
+			}
+		};
+
+		void loadPermissions();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [committeeMember?.id, shouldCheckMemberEdit]);
+
+	const roleSwitchItem = getRoleSwitchItem(
+		location.pathname,
+		menuItems,
+		isCommitteeMember
+	);
 	const footerItems = roleSwitchItem
-		? [...commonItems, roleSwitchItem]
+		? [roleSwitchItem, ...commonItems]
 		: commonItems;
+	const visibleMenuItems =
+		hasMemberEditPermission === false
+			? menuItems.filter(item => item.to !== "/committee/members")
+			: menuItems;
 
 	const renderItem = (item: MenuItem) => {
 		const active = location.pathname.startsWith(item.to);
@@ -165,7 +214,7 @@ export function Sidebar({
 				<div className={styles.projectSelector}>{projectSelector}</div>
 			)}
 
-			<nav className={styles.nav}>{menuItems.map(renderItem)}</nav>
+			<nav className={styles.nav}>{visibleMenuItems.map(renderItem)}</nav>
 
 			<div className={styles.footer}>
 				{footerItems.map(renderItem)}

--- a/apps/web/src/components/layout/Sidebar/menuItems.tsx
+++ b/apps/web/src/components/layout/Sidebar/menuItems.tsx
@@ -9,11 +9,6 @@ import type { MenuItem } from "./Sidebar";
 
 export const projectMenuItems: MenuItem[] = [
 	{
-		label: "メンバー管理",
-		icon: <IconUsers size={18} />,
-		to: "/project/members",
-	},
-	{
 		label: "申請",
 		icon: <IconFileText size={18} />,
 		to: "/project/forms",
@@ -28,14 +23,14 @@ export const projectMenuItems: MenuItem[] = [
 		icon: <IconBell size={18} />,
 		to: "/project/notice",
 	},
-];
-
-export const committeeMenuItems: MenuItem[] = [
 	{
 		label: "メンバー管理",
 		icon: <IconUsers size={18} />,
-		to: "/committee/members",
+		to: "/project/members",
 	},
+];
+
+export const committeeMenuItems: MenuItem[] = [
 	{
 		label: "マスターシート",
 		icon: <IconTable size={18} />,
@@ -52,4 +47,9 @@ export const committeeMenuItems: MenuItem[] = [
 		to: "/committee/support",
 	},
 	{ label: "お知らせ", icon: <IconBell size={18} />, to: "/committee/notice" },
+	{
+		label: "メンバー管理",
+		icon: <IconUsers size={18} />,
+		to: "/committee/members",
+	},
 ];


### PR DESCRIPTION
close #143, #82 
- 表示非表示が切り替わっても違和感がない順番に変更
- disableのスタイルがあんまりまとまらなかったので、非表示にしてみた

実委人切り替えメニュー(権限あり)
<img width="470" height="424" alt="image" src="https://github.com/user-attachments/assets/3cf72557-f3ab-4a65-9303-8bdd5f8d9e04" />

実委人切り替えメニュー(権限なし)
<img width="478" height="364" alt="image" src="https://github.com/user-attachments/assets/aad0bc9a-edce-41a5-977c-4a057b7b6bfd" />

メンバー管理メニュー(権限あり)
<img width="452" height="478" alt="image" src="https://github.com/user-attachments/assets/172a9a89-aed6-42c6-a1e7-9c39e9ae407a" />

メンバー管理メニュー(権限なし)
<img width="476" height="368" alt="image" src="https://github.com/user-attachments/assets/04c417e3-96db-4aa7-b3f1-d674d37afd96" />
