### PR TITLE
企画名重複時のエラー表示と企画番号欠番の防止

### DIFF
--- a/apps/api/src/routes/project.ts
+++ b/apps/api/src/routes/project.ts
@@ -160,6 +160,15 @@ projectRoute.post("/create", requireAuth, async c => {
 		);
 	}
 
+	// ── 企画名の重複確認（事前チェックで欠番を回避） ──
+	const nameTaken = await prisma.project.findUnique({
+		where: { name: data.name },
+		select: { id: true },
+	});
+	if (nameTaken) {
+		throw Errors.alreadyExists("この企画名は既に使用されています");
+	}
+
 	// 企画参加コード生成（衝突回避）
 	let inviteCode = generateInviteCode();
 	while (await prisma.project.findUnique({ where: { inviteCode } })) {
@@ -207,19 +216,23 @@ projectRoute.post("/create", requireAuth, async c => {
 			registrationFormAnswers
 		);
 
-		const created = await tx.project.create({
-			data: {
-				...data,
-				ownerId: userId,
-				subOwnerId: null,
-				inviteCode,
-				projectMembers: {
-					create: {
-						userId: userId,
+		// 事前チェックをすり抜けた並行リクエストのレース対策として
+		// P2002 等を handlePrismaError で AppError に変換する
+		const created = await tx.project
+			.create({
+				data: {
+					...data,
+					ownerId: userId,
+					subOwnerId: null,
+					inviteCode,
+					projectMembers: {
+						create: {
+							userId: userId,
+						},
 					},
 				},
-			},
-		});
+			})
+			.catch(handlePrismaError);
 
 		// 企画登録フォームの回答を保存
 		if (registrationFormAnswers?.length) {

--- a/apps/web/src/components/project/ProjectCreateDialog.tsx
+++ b/apps/web/src/components/project/ProjectCreateDialog.tsx
@@ -7,6 +7,7 @@ import type {
 	RegistrationFormAnswersInput,
 } from "@sos26/shared";
 import {
+	ErrorCode,
 	isBlankProjectDisplayName,
 	isKana,
 	isValidProjectDisplayName,
@@ -33,6 +34,7 @@ import { uploadFile } from "@/lib/api/files";
 import { createProject } from "@/lib/api/project";
 import { getActiveProjectRegistrationForms } from "@/lib/api/project-registration-form";
 import { reportHandledError } from "@/lib/error/report";
+import { isClientError } from "@/lib/http/error";
 import {
 	PROJECT_LOCATION_OPTIONS,
 	PROJECT_TYPE_OPTIONS,
@@ -632,6 +634,12 @@ export function ProjectCreateDialog({ open, onOpenChange, onCreated }: Props) {
 					projectName: step1.name,
 					projectType: type,
 					projectLocation: location,
+				},
+				resolveMessage: ({ error: e, fallbackMessage }) => {
+					if (isClientError(e) && e.code === ErrorCode.ALREADY_EXISTS) {
+						return "この企画名は既に使用されています";
+					}
+					return fallbackMessage;
 				},
 			});
 		} finally {


### PR DESCRIPTION
## 背景
  本番環境で企画番号 (`Project.number` = PostgreSQL SERIAL) に連続した欠番 (34〜45) が発生。                                                                                               
  原因は「企画名重複」で `project.create` が番号を消費した直後に `@unique` 制約違反で                                                                                                      
  ロールバックしていたため（PostgreSQL の SERIAL はロールバック時に値が戻らない）。                                                                                                        
                                                                                                                                                                                           
  ## 変更内容                                                                                                                                                                              
                                                                                                                                                                                           
  ### API (`apps/api/src/routes/project.ts`)                
  - `POST /project/create` のトランザクション外で企画名の事前重複チェックを追加
    → 通常ケースでは `project.create` に到達せず、番号が消費されない                                                                                                                       
  - `tx.project.create` に `.catch(handlePrismaError)` を追加                                                                                                                              
    → 並行リクエストのレース時も 500 ではなく `ALREADY_EXISTS` (409) で応答                                                                                                                
                                                                                                                                                                                           
  ### Web (`apps/web/src/components/project/ProjectCreateDialog.tsx`)                                                                                                                      
  - `reportHandledError` の `resolveMessage` で `ErrorCode.ALREADY_EXISTS` を判定し、                                                                                                      
    Toast に「この企画名は既に使用されています」を表示                                                                                                                                     
                                                                                                                                                                                           
  ## 動作                                                                                                                                                                                  
  | ケース | 挙動 |                                                                                                                                                                        
  |---|---|                                                 
  | 既存名で送信（通常） | 事前チェックで弾く。番号欠番なし、適切な Toast |
  | 並行リクエストのレース | `create` で P2002 → 409 応答、適切な Toast（番号は1個欠番） |                                                                                                 

<img width="971" height="727" alt="スクリーンショット 2026-04-21 9 11 24" src="https://github.com/user-attachments/assets/2fd2088e-24ae-4422-8776-8d5758691934" />
