### PR TITLE
スクロール保存を修正

### DIFF
--- a/apps/web/src/components/support/SupportDetail.tsx
+++ b/apps/web/src/components/support/SupportDetail.tsx
@@ -16,7 +16,7 @@ import {
 	IconTrash,
 	IconUsers,
 } from "@tabler/icons-react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { Button } from "@/components/primitives";
 import { formatDate, formatProjectNumber } from "@/lib/format";
@@ -672,7 +672,6 @@ export function SupportDetail({
 	onUpdateViewers,
 	isAssigneeOrAdmin = false,
 }: SupportDetailProps) {
-	const navigate = useNavigate();
 	const [activeReplyTab, setActiveReplyTab] = useState<"comment" | "draft">(
 		"comment"
 	);
@@ -799,7 +798,9 @@ export function SupportDetail({
 				<button
 					type="button"
 					className={styles.backLink}
-					onClick={() => navigate({ to: basePath as string })}
+					onClick={() => {
+						window.history.back();
+					}}
 				>
 					<IconArrowLeft size={16} />
 					<Text size="2">お問い合わせ一覧に戻る</Text>

--- a/apps/web/src/components/support/SupportList.tsx
+++ b/apps/web/src/components/support/SupportList.tsx
@@ -28,6 +28,8 @@ type SupportListProps = {
 	basePath: string;
 	onNewInquiry: () => void;
 	isAdmin?: boolean;
+	committeeActiveTab?: CommitteeTab;
+	onCommitteeTabChange?: (tab: CommitteeTab) => void;
 };
 
 type CommitteeTab = "open" | "draft" | "resolved";
@@ -39,10 +41,18 @@ export function SupportList({
 	basePath,
 	onNewInquiry,
 	isAdmin = false,
+	committeeActiveTab,
+	onCommitteeTabChange,
 }: SupportListProps) {
-	const [activeTab, setActiveTab] = useState<CommitteeTab>("open");
+	const [localActiveTab, setLocalActiveTab] = useState<CommitteeTab>("open");
 	const [searchQuery, setSearchQuery] = useState("");
 	const isCommittee = viewerRole === "committee";
+	const activeTab = committeeActiveTab ?? localActiveTab;
+
+	const handleChangeTab = (tab: CommitteeTab) => {
+		setLocalActiveTab(tab);
+		onCommitteeTabChange?.(tab);
+	};
 
 	const searched = (() => {
 		const q = searchQuery.trim().toLowerCase();
@@ -116,7 +126,7 @@ export function SupportList({
 						activeTab={activeTab}
 						myCount={myCount}
 						draftCount={draftItems.length}
-						onChangeTab={setActiveTab}
+						onChangeTab={handleChangeTab}
 					/>
 				)}
 				<div className={styles.search}>

--- a/apps/web/src/routes/committee/forms/$formId/index.tsx
+++ b/apps/web/src/routes/committee/forms/$formId/index.tsx
@@ -17,7 +17,6 @@ import {
 } from "@tabler/icons-react";
 import {
 	createFileRoute,
-	Link,
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
@@ -399,10 +398,14 @@ function RouteComponent() {
 	return (
 		<div className={styles.layout}>
 			<div className={styles.main}>
-				<Link to="/committee/forms" className={styles.backLink}>
+				<button
+					type="button"
+					className={styles.backLink}
+					onClick={() => window.history.back()}
+				>
 					<IconArrowLeft size={16} />
 					<Text size="2">申請一覧に戻る</Text>
-				</Link>
+				</button>
 
 				<header className={styles.titleSection}>
 					<FormStatusBadge form={form} />

--- a/apps/web/src/routes/committee/notice/$noticeId/index.tsx
+++ b/apps/web/src/routes/committee/notice/$noticeId/index.tsx
@@ -164,7 +164,7 @@ function RouteComponent() {
 				<button
 					type="button"
 					className={styles.backLink}
-					onClick={() => navigate({ to: "/committee/notice" })}
+					onClick={() => window.history.back()}
 				>
 					<IconArrowLeft size={16} />
 					<Text size="2">お知らせ一覧に戻る</Text>

--- a/apps/web/src/routes/committee/project-registration/$formId/index.tsx
+++ b/apps/web/src/routes/committee/project-registration/$formId/index.tsx
@@ -3,7 +3,6 @@ import type { ProjectRegistrationFormDetail } from "@sos26/shared";
 import { IconArrowLeft, IconCalendar, IconClock } from "@tabler/icons-react";
 import {
 	createFileRoute,
-	Link,
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
@@ -248,10 +247,14 @@ function RouteComponent() {
 	return (
 		<div className={styles.layout}>
 			<div className={styles.main}>
-				<Link to="/committee/project-registration" className={styles.backLink}>
+				<button
+					type="button"
+					className={styles.backLink}
+					onClick={() => window.history.back()}
+				>
 					<IconArrowLeft size={16} />
 					<Text size="2">企画登録管理に戻る</Text>
-				</Link>
+				</button>
 
 				<header className={styles.titleSection}>
 					<div>

--- a/apps/web/src/routes/committee/support/$inquiryId.tsx
+++ b/apps/web/src/routes/committee/support/$inquiryId.tsx
@@ -104,7 +104,7 @@ function CommitteeSupportDetailPage() {
 				<Text as="p" size="2" color="gray">
 					指定されたお問い合わせは存在しないか、削除された可能性があります。
 				</Text>
-				<Link to="/committee/support">
+				<Link to="/committee/support" search={{ tab: "open" }}>
 					<Button intent="secondary">一覧に戻る</Button>
 				</Link>
 			</div>
@@ -294,7 +294,10 @@ function CommitteeSupportDetailPage() {
 				try {
 					await deleteDraftInquiry(inquiryId);
 					toast.success("下書きを削除しました");
-					router.navigate({ to: "/committee/support" });
+					router.navigate({
+						to: "/committee/support",
+						search: { tab: "draft" },
+					});
 				} catch (error) {
 					reportHandledError({
 						error,

--- a/apps/web/src/routes/committee/support/index.tsx
+++ b/apps/web/src/routes/committee/support/index.tsx
@@ -4,6 +4,7 @@ import {
 	useRouter,
 } from "@tanstack/react-router";
 import { useState } from "react";
+import { z } from "zod";
 import { NewInquiryForm } from "@/components/support/NewInquiryForm";
 import { SupportList } from "@/components/support/SupportList";
 import { listMyForms } from "@/lib/api/committee-form";
@@ -21,7 +22,12 @@ import {
 } from "@/lib/api/committee-project";
 import { useAuthStore } from "@/lib/auth";
 
+const searchSchema = z.object({
+	tab: z.enum(["open", "draft", "resolved"]).catch("open"),
+});
+
 export const Route = createFileRoute("/committee/support/")({
+	validateSearch: searchSchema,
 	component: CommitteeSupportListPage,
 	head: () => ({
 		meta: [
@@ -82,6 +88,7 @@ export const Route = createFileRoute("/committee/support/")({
 });
 
 function CommitteeSupportListPage() {
+	const { tab } = Route.useSearch();
 	const { inquiries, projects, committeeMembers, availableForms, isAdmin } =
 		Route.useLoaderData();
 	const [formOpen, setFormOpen] = useState(false);
@@ -111,6 +118,14 @@ function CommitteeSupportListPage() {
 				basePath="/committee/support"
 				onNewInquiry={() => setFormOpen(true)}
 				isAdmin={isAdmin}
+				committeeActiveTab={tab}
+				onCommitteeTabChange={nextTab => {
+					navigate({
+						to: ".",
+						search: prev => ({ ...prev, tab: nextTab }),
+						replace: true,
+					});
+				}}
 			/>
 			<NewInquiryForm
 				open={formOpen}


### PR DESCRIPTION
～～一覧に戻るがほとんどnavigateで実装されており、tanstack routerのスクロール保存がきいていなかった。
また、お問い合わせにおいて、未完了、下書きなどのタブもページ遷移しても保存されるようにした。