### PR TITLE
メンバー一覧取得にMEMBER_EDIT権限チェックを追加

### DIFF
--- a/apps/api/src/routes/committee-member.test.ts
+++ b/apps/api/src/routes/committee-member.test.ts
@@ -177,6 +177,76 @@ describe("GET /committee/members", () => {
 	});
 });
 
+describe("GET /committee/members/directory", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("正常系: MEMBER_EDIT 権限なしでも取得できる", async () => {
+		const app = makeApp();
+		mockFirebaseAuth.verifyIdToken.mockResolvedValue({
+			uid: "firebase-uid-123",
+		} as any);
+		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+		// requireCommitteeMember 用（権限なし実委メンバー）
+		mockPrisma.committeeMember.findFirst.mockResolvedValue(mockCommitteeMember);
+		// directory 用の findMany は最小情報のみ
+		mockPrisma.committeeMember.findMany.mockResolvedValue([
+			{
+				id: mockCommitteeMember.id,
+				userId: mockCommitteeMember.userId,
+				isExecutive: mockCommitteeMember.isExecutive,
+				Bureau: mockCommitteeMember.Bureau,
+				user: {
+					id: mockUser.id,
+					name: mockUser.name,
+					avatarFileId: null,
+				},
+				permissions: [],
+			},
+		] as any);
+
+		const res = await app.request("/committee/members/directory", {
+			method: "GET",
+			headers: { Authorization: "Bearer valid-token" },
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.committeeMembers).toHaveLength(1);
+		expect(body.committeeMembers[0].user.name).toBe(mockUser.name);
+		// 個人情報が含まれないこと
+		expect(body.committeeMembers[0].user.email).toBeUndefined();
+		expect(body.committeeMembers[0].user.telephoneNumber).toBeUndefined();
+	});
+
+	it("認証なしで401エラー", async () => {
+		const app = makeApp();
+
+		const res = await app.request("/committee/members/directory", {
+			method: "GET",
+		});
+
+		expect(res.status).toBe(401);
+	});
+
+	it("非委員で403エラー", async () => {
+		const app = makeApp();
+		mockFirebaseAuth.verifyIdToken.mockResolvedValue({
+			uid: "firebase-uid-123",
+		} as any);
+		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+		mockPrisma.committeeMember.findFirst.mockResolvedValue(null);
+
+		const res = await app.request("/committee/members/directory", {
+			method: "GET",
+			headers: { Authorization: "Bearer valid-token" },
+		});
+
+		expect(res.status).toBe(403);
+	});
+});
+
 describe("POST /committee/members", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/apps/api/src/routes/committee-member.test.ts
+++ b/apps/api/src/routes/committee-member.test.ts
@@ -95,16 +95,6 @@ function makeApp() {
 	return app;
 }
 
-/** 認証 + 実委メンバーチェックをセットアップ（権限チェックなし） */
-function setupAuth() {
-	mockFirebaseAuth.verifyIdToken.mockResolvedValue({
-		uid: "firebase-uid-123",
-	} as any);
-	mockPrisma.user.findFirst.mockResolvedValue(mockUser);
-	// requireCommitteeMember 用
-	mockPrisma.committeeMember.findFirst.mockResolvedValue(mockCommitteeMember);
-}
-
 /** 認証 + 実委メンバーチェック + MEMBER_EDIT 権限チェックをセットアップ */
 function setupAuthWithMemberEdit() {
 	mockFirebaseAuth.verifyIdToken.mockResolvedValue({
@@ -124,7 +114,7 @@ describe("GET /committee/members", () => {
 
 	it("正常系: 委員メンバー一覧を取得", async () => {
 		const app = makeApp();
-		setupAuth();
+		setupAuthWithMemberEdit();
 		mockPrisma.committeeMember.findMany.mockResolvedValue([
 			{ ...mockCommitteeMember, user: mockUser },
 		] as any);
@@ -157,6 +147,26 @@ describe("GET /committee/members", () => {
 		} as any);
 		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
 		mockPrisma.committeeMember.findFirst.mockResolvedValue(null);
+
+		const res = await app.request("/committee/members", {
+			method: "GET",
+			headers: { Authorization: "Bearer valid-token" },
+		});
+
+		expect(res.status).toBe(403);
+	});
+
+	it("MEMBER_EDIT権限なしで403エラー", async () => {
+		const app = makeApp();
+		mockFirebaseAuth.verifyIdToken.mockResolvedValue({
+			uid: "firebase-uid-123",
+		} as any);
+		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+		// requireCommitteeMember は通るが MEMBER_EDIT 権限なし
+		mockPrisma.committeeMember.findFirst.mockResolvedValue({
+			...mockCommitteeMember,
+			permissions: [],
+		} as any);
 
 		const res = await app.request("/committee/members", {
 			method: "GET",

--- a/apps/api/src/routes/committee-member.test.ts
+++ b/apps/api/src/routes/committee-member.test.ts
@@ -182,7 +182,7 @@ describe("GET /committee/members", () => {
 	});
 });
 
-describe("GET /committee/members/directory", () => {
+describe("GET /committee/members/picker", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
@@ -195,7 +195,7 @@ describe("GET /committee/members/directory", () => {
 		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
 		// requireCommitteeMember 用（権限なし実委メンバー）
 		mockPrisma.committeeMember.findFirst.mockResolvedValue(mockCommitteeMember);
-		// directory 用の findMany は最小情報のみ
+		// picker 用の findMany は最小情報のみ
 		mockPrisma.committeeMember.findMany.mockResolvedValue([
 			{
 				id: mockCommitteeMember.id,
@@ -211,7 +211,7 @@ describe("GET /committee/members/directory", () => {
 			},
 		] as any);
 
-		const res = await app.request("/committee/members/directory", {
+		const res = await app.request("/committee/members/picker", {
 			method: "GET",
 			headers: { Authorization: "Bearer valid-token" },
 		});
@@ -228,7 +228,7 @@ describe("GET /committee/members/directory", () => {
 	it("認証なしで401エラー", async () => {
 		const app = makeApp();
 
-		const res = await app.request("/committee/members/directory", {
+		const res = await app.request("/committee/members/picker", {
 			method: "GET",
 		});
 
@@ -243,7 +243,7 @@ describe("GET /committee/members/directory", () => {
 		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
 		mockPrisma.committeeMember.findFirst.mockResolvedValue(null);
 
-		const res = await app.request("/committee/members/directory", {
+		const res = await app.request("/committee/members/picker", {
 			method: "GET",
 			headers: { Authorization: "Bearer valid-token" },
 		});

--- a/apps/api/src/routes/committee-member.test.ts
+++ b/apps/api/src/routes/committee-member.test.ts
@@ -107,6 +107,19 @@ function setupAuthWithMemberEdit() {
 	);
 }
 
+/** 認証 + 実委メンバーチェックのみ（MEMBER_EDIT 権限なし）をセットアップ */
+function setupAuthWithoutMemberEdit() {
+	mockFirebaseAuth.verifyIdToken.mockResolvedValue({
+		uid: "firebase-uid-123",
+	} as any);
+	mockPrisma.user.findFirst.mockResolvedValue(mockUser);
+	// requireCommitteeMember は通るが MEMBER_EDIT 権限なし
+	mockPrisma.committeeMember.findFirst.mockResolvedValue({
+		...mockCommitteeMember,
+		permissions: [],
+	} as any);
+}
+
 describe("GET /committee/members", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -158,15 +171,7 @@ describe("GET /committee/members", () => {
 
 	it("MEMBER_EDIT権限なしで403エラー", async () => {
 		const app = makeApp();
-		mockFirebaseAuth.verifyIdToken.mockResolvedValue({
-			uid: "firebase-uid-123",
-		} as any);
-		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
-		// requireCommitteeMember は通るが MEMBER_EDIT 権限なし
-		mockPrisma.committeeMember.findFirst.mockResolvedValue({
-			...mockCommitteeMember,
-			permissions: [],
-		} as any);
+		setupAuthWithoutMemberEdit();
 
 		const res = await app.request("/committee/members", {
 			method: "GET",
@@ -254,15 +259,7 @@ describe("POST /committee/members", () => {
 
 	it("MEMBER_EDIT権限なしで403エラー", async () => {
 		const app = makeApp();
-		mockFirebaseAuth.verifyIdToken.mockResolvedValue({
-			uid: "firebase-uid-123",
-		} as any);
-		mockPrisma.user.findFirst.mockResolvedValue(mockUser);
-		// requireCommitteeMember + requirePermission（権限なし）
-		mockPrisma.committeeMember.findFirst.mockResolvedValue({
-			...mockCommitteeMember,
-			permissions: [],
-		} as any);
+		setupAuthWithoutMemberEdit();
 
 		const res = await app.request("/committee/members", {
 			method: "POST",

--- a/apps/api/src/routes/committee-member.ts
+++ b/apps/api/src/routes/committee-member.ts
@@ -19,6 +19,14 @@ const committeeMemberRoute = new Hono<AuthEnv>();
 // 委員メンバー一覧を取得
 // ─────────────────────────────────────────────────────────────
 committeeMemberRoute.get("/", requireAuth, requireCommitteeMember, async c => {
+	const user = c.get("user");
+	await requirePermission(
+		prisma,
+		user.id,
+		"MEMBER_EDIT",
+		"メンバー編集権限がありません"
+	);
+
 	const committeeMembers = await prisma.committeeMember.findMany({
 		where: { deletedAt: null },
 		include: { user: true, permissions: true },

--- a/apps/api/src/routes/committee-member.ts
+++ b/apps/api/src/routes/committee-member.ts
@@ -171,6 +171,41 @@ committeeMemberRoute.delete(
 );
 
 // ─────────────────────────────────────────────────────────────
+// GET /committee/members/directory
+// 候補者ピッカー用の委員メンバー一覧（最小情報・MEMBER_EDIT 不要）
+// ─────────────────────────────────────────────────────────────
+committeeMemberRoute.get(
+	"/directory",
+	requireAuth,
+	requireCommitteeMember,
+	async c => {
+		const committeeMembers = await prisma.committeeMember.findMany({
+			where: { deletedAt: null },
+			select: {
+				id: true,
+				userId: true,
+				isExecutive: true,
+				Bureau: true,
+				user: {
+					select: {
+						id: true,
+						name: true,
+						avatarFileId: true,
+					},
+				},
+				permissions: {
+					select: {
+						permission: true,
+					},
+				},
+			},
+		});
+
+		return c.json({ committeeMembers });
+	}
+);
+
+// ─────────────────────────────────────────────────────────────
 // GET /committee/members/me/permissions
 // 自分自身の権限一覧を取得（MEMBER_EDIT 不要）
 // ─────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/committee-member.ts
+++ b/apps/api/src/routes/committee-member.ts
@@ -36,6 +36,41 @@ committeeMemberRoute.get("/", requireAuth, requireCommitteeMember, async c => {
 });
 
 // ─────────────────────────────────────────────────────────────
+// GET /committee/members/directory
+// 候補者ピッカー用の委員メンバー一覧（最小情報・MEMBER_EDIT 不要）
+// ─────────────────────────────────────────────────────────────
+committeeMemberRoute.get(
+	"/directory",
+	requireAuth,
+	requireCommitteeMember,
+	async c => {
+		const committeeMembers = await prisma.committeeMember.findMany({
+			where: { deletedAt: null },
+			select: {
+				id: true,
+				userId: true,
+				isExecutive: true,
+				Bureau: true,
+				user: {
+					select: {
+						id: true,
+						name: true,
+						avatarFileId: true,
+					},
+				},
+				permissions: {
+					select: {
+						permission: true,
+					},
+				},
+			},
+		});
+
+		return c.json({ committeeMembers });
+	}
+);
+
+// ─────────────────────────────────────────────────────────────
 // POST /committee/members
 // 委員メンバーを作成
 // ─────────────────────────────────────────────────────────────
@@ -167,41 +202,6 @@ committeeMemberRoute.delete(
 		});
 
 		return c.json({ success: true });
-	}
-);
-
-// ─────────────────────────────────────────────────────────────
-// GET /committee/members/directory
-// 候補者ピッカー用の委員メンバー一覧（最小情報・MEMBER_EDIT 不要）
-// ─────────────────────────────────────────────────────────────
-committeeMemberRoute.get(
-	"/directory",
-	requireAuth,
-	requireCommitteeMember,
-	async c => {
-		const committeeMembers = await prisma.committeeMember.findMany({
-			where: { deletedAt: null },
-			select: {
-				id: true,
-				userId: true,
-				isExecutive: true,
-				Bureau: true,
-				user: {
-					select: {
-						id: true,
-						name: true,
-						avatarFileId: true,
-					},
-				},
-				permissions: {
-					select: {
-						permission: true,
-					},
-				},
-			},
-		});
-
-		return c.json({ committeeMembers });
 	}
 );
 

--- a/apps/api/src/routes/committee-member.ts
+++ b/apps/api/src/routes/committee-member.ts
@@ -36,11 +36,11 @@ committeeMemberRoute.get("/", requireAuth, requireCommitteeMember, async c => {
 });
 
 // ─────────────────────────────────────────────────────────────
-// GET /committee/members/directory
+// GET /committee/members/picker
 // 候補者ピッカー用の委員メンバー一覧（最小情報・MEMBER_EDIT 不要）
 // ─────────────────────────────────────────────────────────────
 committeeMemberRoute.get(
-	"/directory",
+	"/picker",
 	requireAuth,
 	requireCommitteeMember,
 	async c => {

--- a/apps/web/src/lib/api/committee-member.ts
+++ b/apps/web/src/lib/api/committee-member.ts
@@ -10,8 +10,10 @@ import {
 	getMyPermissionsEndpoint,
 	grantCommitteeMemberPermissionEndpoint,
 	type ListCommitteeMemberPermissionsResponse,
+	type ListCommitteeMembersDirectoryResponse,
 	type ListCommitteeMembersResponse,
 	listCommitteeMemberPermissionsEndpoint,
+	listCommitteeMembersDirectoryEndpoint,
 	listCommitteeMembersEndpoint,
 	type RevokeCommitteeMemberPermissionResponse,
 	revokeCommitteeMemberPermissionEndpoint,
@@ -22,11 +24,24 @@ import {
 import { callBodyApi, callGetApi, callNoBodyApi } from "./core";
 
 /**
- * GET /committee-members
- * 委員メンバー一覧を取得
+ * GET /committee/members
+ * 委員メンバー一覧を取得（管理画面用・フル情報）
+ *
+ * MEMBER_EDIT 権限が必須。候補者ピッカーなど MEMBER_EDIT を持たない
+ * ユーザーが利用する場合は {@link listCommitteeMembersDirectory} を使うこと。
  */
 export async function listCommitteeMembers(): Promise<ListCommitteeMembersResponse> {
 	return callGetApi(listCommitteeMembersEndpoint);
+}
+
+/**
+ * GET /committee/members/directory
+ * 候補者ピッカー用の委員メンバー一覧を取得（最小情報）
+ *
+ * MEMBER_EDIT 権限は不要。email / telephoneNumber などの個人情報は含まない。
+ */
+export async function listCommitteeMembersDirectory(): Promise<ListCommitteeMembersDirectoryResponse> {
+	return callGetApi(listCommitteeMembersDirectoryEndpoint);
 }
 
 /**

--- a/apps/web/src/lib/api/committee-member.ts
+++ b/apps/web/src/lib/api/committee-member.ts
@@ -45,7 +45,7 @@ export async function listCommitteeMembersDirectory(): Promise<ListCommitteeMemb
 }
 
 /**
- * POST /committee-members
+ * POST /committee/members
  * 委員メンバーを作成
  */
 export async function createCommitteeMember(
@@ -55,7 +55,7 @@ export async function createCommitteeMember(
 }
 
 /**
- * PATCH /committee-members/:id
+ * PATCH /committee/members/:id
  * 委員メンバーを更新
  */
 export async function updateCommitteeMember(
@@ -68,7 +68,7 @@ export async function updateCommitteeMember(
 }
 
 /**
- * DELETE /committee-members/:id
+ * DELETE /committee/members/:id
  * 委員メンバーをソフトデリート
  */
 export async function deleteCommitteeMember(

--- a/apps/web/src/lib/api/committee-member.ts
+++ b/apps/web/src/lib/api/committee-member.ts
@@ -10,11 +10,11 @@ import {
 	getMyPermissionsEndpoint,
 	grantCommitteeMemberPermissionEndpoint,
 	type ListCommitteeMemberPermissionsResponse,
-	type ListCommitteeMembersDirectoryResponse,
+	type ListCommitteeMembersPickerResponse,
 	type ListCommitteeMembersResponse,
 	listCommitteeMemberPermissionsEndpoint,
-	listCommitteeMembersDirectoryEndpoint,
 	listCommitteeMembersEndpoint,
+	listCommitteeMembersPickerEndpoint,
 	type RevokeCommitteeMemberPermissionResponse,
 	revokeCommitteeMemberPermissionEndpoint,
 	type UpdateCommitteeMemberRequest,
@@ -28,20 +28,20 @@ import { callBodyApi, callGetApi, callNoBodyApi } from "./core";
  * 委員メンバー一覧を取得（管理画面用・フル情報）
  *
  * MEMBER_EDIT 権限が必須。候補者ピッカーなど MEMBER_EDIT を持たない
- * ユーザーが利用する場合は {@link listCommitteeMembersDirectory} を使うこと。
+ * ユーザーが利用する場合は {@link listCommitteeMembersPicker} を使うこと。
  */
 export async function listCommitteeMembers(): Promise<ListCommitteeMembersResponse> {
 	return callGetApi(listCommitteeMembersEndpoint);
 }
 
 /**
- * GET /committee/members/directory
+ * GET /committee/members/picker
  * 候補者ピッカー用の委員メンバー一覧を取得（最小情報）
  *
  * MEMBER_EDIT 権限は不要。email / telephoneNumber などの個人情報は含まない。
  */
-export async function listCommitteeMembersDirectory(): Promise<ListCommitteeMembersDirectoryResponse> {
-	return callGetApi(listCommitteeMembersDirectoryEndpoint);
+export async function listCommitteeMembersPicker(): Promise<ListCommitteeMembersPickerResponse> {
+	return callGetApi(listCommitteeMembersPickerEndpoint);
 }
 
 /**

--- a/apps/web/src/routes/committee/forms/$formId/index.tsx
+++ b/apps/web/src/routes/committee/forms/$formId/index.tsx
@@ -38,7 +38,7 @@ import {
 	removeFormCollaborator,
 	updateFormViewers,
 } from "@/lib/api/committee-form";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import { useAuthStore } from "@/lib/auth";
 import { reportHandledError } from "@/lib/error/report";
 import { formDetailToForm } from "@/lib/form/convert";
@@ -137,7 +137,7 @@ export const Route = createFileRoute("/committee/forms/$formId/")({
 	loader: async ({ params }) => {
 		const [formRes, membersRes, responsesRes] = await Promise.all([
 			getFormDetail(params.formId),
-			listCommitteeMembers(),
+			listCommitteeMembersDirectory(),
 			listFormResponses(params.formId).catch(() => ({ responses: [] })),
 		]);
 		return {

--- a/apps/web/src/routes/committee/forms/$formId/index.tsx
+++ b/apps/web/src/routes/committee/forms/$formId/index.tsx
@@ -38,7 +38,7 @@ import {
 	removeFormCollaborator,
 	updateFormViewers,
 } from "@/lib/api/committee-form";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import { useAuthStore } from "@/lib/auth";
 import { reportHandledError } from "@/lib/error/report";
 import { formDetailToForm } from "@/lib/form/convert";
@@ -137,7 +137,7 @@ export const Route = createFileRoute("/committee/forms/$formId/")({
 	loader: async ({ params }) => {
 		const [formRes, membersRes, responsesRes] = await Promise.all([
 			getFormDetail(params.formId),
-			listCommitteeMembersDirectory(),
+			listCommitteeMembersPicker(),
 			listFormResponses(params.formId).catch(() => ({ responses: [] })),
 		]);
 		return {

--- a/apps/web/src/routes/committee/mastersheet/-components/AddCustomColumnDialog.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/AddCustomColumnDialog.tsx
@@ -16,7 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button, IconButton, Select, TextField } from "@/components/primitives";
 import { createMastersheetColumn } from "@/lib/api/committee-mastersheet";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import { isClientError } from "@/lib/http/error";
 import styles from "./AddCustomColumnDialog.module.scss";
 import { ViewerSelector } from "./ViewerSelector";
@@ -90,7 +90,7 @@ export function AddCustomColumnDialog({
 
 	useEffect(() => {
 		if (!open) return;
-		listCommitteeMembers()
+		listCommitteeMembersDirectory()
 			.then(res =>
 				setCommitteeMembers(
 					res.committeeMembers.map(m => ({ id: m.user.id, name: m.user.name }))

--- a/apps/web/src/routes/committee/mastersheet/-components/AddCustomColumnDialog.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/AddCustomColumnDialog.tsx
@@ -16,7 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button, IconButton, Select, TextField } from "@/components/primitives";
 import { createMastersheetColumn } from "@/lib/api/committee-mastersheet";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import { isClientError } from "@/lib/http/error";
 import styles from "./AddCustomColumnDialog.module.scss";
 import { ViewerSelector } from "./ViewerSelector";
@@ -90,7 +90,7 @@ export function AddCustomColumnDialog({
 
 	useEffect(() => {
 		if (!open) return;
-		listCommitteeMembersDirectory()
+		listCommitteeMembersPicker()
 			.then(res =>
 				setCommitteeMembers(
 					res.committeeMembers.map(m => ({ id: m.user.id, name: m.user.name }))

--- a/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
@@ -35,7 +35,7 @@ import {
 	updateMastersheetAccessRequest,
 	updateMastersheetColumn,
 } from "@/lib/api/committee-mastersheet";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import {
 	getProjectRegistrationFormDetail,
 	listProjectRegistrationForms,
@@ -232,7 +232,7 @@ function EditColumnForm({ col, onSuccess, onCancel }: EditColumnFormProps) {
 	}
 
 	useEffect(() => {
-		listCommitteeMembers()
+		listCommitteeMembersDirectory()
 			.then(res =>
 				setCommitteeMembers(
 					res.committeeMembers.map(m => ({ id: m.user.id, name: m.user.name }))

--- a/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
@@ -35,7 +35,7 @@ import {
 	updateMastersheetAccessRequest,
 	updateMastersheetColumn,
 } from "@/lib/api/committee-mastersheet";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import {
 	getProjectRegistrationFormDetail,
 	listProjectRegistrationForms,
@@ -232,7 +232,7 @@ function EditColumnForm({ col, onSuccess, onCancel }: EditColumnFormProps) {
 	}
 
 	useEffect(() => {
-		listCommitteeMembersDirectory()
+		listCommitteeMembersPicker()
 			.then(res =>
 				setCommitteeMembers(
 					res.committeeMembers.map(m => ({ id: m.user.id, name: m.user.name }))

--- a/apps/web/src/routes/committee/members/index.tsx
+++ b/apps/web/src/routes/committee/members/index.tsx
@@ -32,7 +32,6 @@ import { Button } from "@/components/primitives";
 import {
 	createCommitteeMember,
 	deleteCommitteeMember,
-	getMyPermissions,
 	grantCommitteeMemberPermission,
 	listCommitteeMembers,
 	revokeCommitteeMemberPermission,
@@ -295,14 +294,12 @@ export const Route = createFileRoute("/committee/members/")({
 		meta: [{ title: "メンバー管理 | 雙峰祭オンラインシステム" }],
 	}),
 	loader: async () => {
-		const { permissions } = await getMyPermissions();
-		const hasMemberEdit = permissions.some(p => p.permission === "MEMBER_EDIT");
-
-		if (!hasMemberEdit) {
-			throw new ForbiddenError();
-		}
-
-		const data = await listCommitteeMembers();
+		const data = await listCommitteeMembers().catch(error => {
+			if (isClientError(error) && error.code === "FORBIDDEN") {
+				throw new ForbiddenError();
+			}
+			throw error;
+		});
 
 		return {
 			members: data.committeeMembers.map(m => ({

--- a/apps/web/src/routes/committee/members/index.tsx
+++ b/apps/web/src/routes/committee/members/index.tsx
@@ -32,6 +32,7 @@ import { Button } from "@/components/primitives";
 import {
 	createCommitteeMember,
 	deleteCommitteeMember,
+	getMyPermissions,
 	grantCommitteeMemberPermission,
 	listCommitteeMembers,
 	revokeCommitteeMemberPermission,
@@ -294,17 +295,14 @@ export const Route = createFileRoute("/committee/members/")({
 		meta: [{ title: "メンバー管理 | 雙峰祭オンラインシステム" }],
 	}),
 	loader: async () => {
-		const { user } = useAuthStore.getState();
-		const data = await listCommitteeMembers();
-
-		const me = data.committeeMembers.find(m => m.userId === user?.id);
-		const hasMemberEdit = me?.permissions.some(
-			p => p.permission === "MEMBER_EDIT"
-		);
+		const { permissions } = await getMyPermissions();
+		const hasMemberEdit = permissions.some(p => p.permission === "MEMBER_EDIT");
 
 		if (!hasMemberEdit) {
 			throw new ForbiddenError();
 		}
+
+		const data = await listCommitteeMembers();
 
 		return {
 			members: data.committeeMembers.map(m => ({

--- a/apps/web/src/routes/committee/notice/$noticeId/index.tsx
+++ b/apps/web/src/routes/committee/notice/$noticeId/index.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AttachmentPreviewButton } from "@/components/filePreview/AttachmentPreviewButton";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import {
 	addCollaborator,
 	deleteNotice,
@@ -41,7 +41,7 @@ export const Route = createFileRoute("/committee/notice/$noticeId/")({
 	loader: async ({ params }) => {
 		const [noticeRes, membersRes] = await Promise.all([
 			getNotice(params.noticeId),
-			listCommitteeMembersDirectory(),
+			listCommitteeMembersPicker(),
 		]);
 		return {
 			notice: noticeRes.notice,

--- a/apps/web/src/routes/committee/notice/$noticeId/index.tsx
+++ b/apps/web/src/routes/committee/notice/$noticeId/index.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AttachmentPreviewButton } from "@/components/filePreview/AttachmentPreviewButton";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import {
 	addCollaborator,
 	deleteNotice,
@@ -41,7 +41,7 @@ export const Route = createFileRoute("/committee/notice/$noticeId/")({
 	loader: async ({ params }) => {
 		const [noticeRes, membersRes] = await Promise.all([
 			getNotice(params.noticeId),
-			listCommitteeMembers(),
+			listCommitteeMembersDirectory(),
 		]);
 		return {
 			notice: noticeRes.notice,

--- a/apps/web/src/routes/committee/project-registration/$formId/index.tsx
+++ b/apps/web/src/routes/committee/project-registration/$formId/index.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { Form } from "@/components/form/type";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import {
 	addProjectRegistrationFormCollaborator,
 	deleteProjectRegistrationForm,
@@ -63,7 +63,7 @@ export const Route = createFileRoute(
 		const [{ form }, { committeeMembers }, { forms: allForms }] =
 			await Promise.all([
 				getProjectRegistrationFormDetail(params.formId),
-				listCommitteeMembersDirectory(),
+				listCommitteeMembersPicker(),
 				listProjectRegistrationForms(),
 			]);
 		const currentUserId = useAuthStore.getState().user?.id;

--- a/apps/web/src/routes/committee/project-registration/$formId/index.tsx
+++ b/apps/web/src/routes/committee/project-registration/$formId/index.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { Form } from "@/components/form/type";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import {
 	addProjectRegistrationFormCollaborator,
 	deleteProjectRegistrationForm,
@@ -63,7 +63,7 @@ export const Route = createFileRoute(
 		const [{ form }, { committeeMembers }, { forms: allForms }] =
 			await Promise.all([
 				getProjectRegistrationFormDetail(params.formId),
-				listCommitteeMembers(),
+				listCommitteeMembersDirectory(),
 				listProjectRegistrationForms(),
 			]);
 		const currentUserId = useAuthStore.getState().user?.id;

--- a/apps/web/src/routes/committee/project-registration/index.tsx
+++ b/apps/web/src/routes/committee/project-registration/index.tsx
@@ -5,7 +5,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { useState } from "react";
 import { DataTable, DateCell, NameCell } from "@/components/patterns";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
+import { listCommitteeMembersPicker } from "@/lib/api/committee-member";
 import { listProjectRegistrationForms } from "@/lib/api/committee-project-registration-form";
 import { useAuthStore } from "@/lib/auth";
 import {
@@ -47,7 +47,7 @@ export const Route = createFileRoute("/committee/project-registration/")({
 	loader: async (): Promise<LoaderData> => {
 		const [{ forms }, { committeeMembers }] = await Promise.all([
 			listProjectRegistrationForms(),
-			listCommitteeMembersDirectory(),
+			listCommitteeMembersPicker(),
 		]);
 
 		const currentUserId = useAuthStore.getState().user?.id;

--- a/apps/web/src/routes/committee/project-registration/index.tsx
+++ b/apps/web/src/routes/committee/project-registration/index.tsx
@@ -5,7 +5,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { useState } from "react";
 import { DataTable, DateCell, NameCell } from "@/components/patterns";
 import { Button } from "@/components/primitives";
-import { listCommitteeMembers } from "@/lib/api/committee-member";
+import { listCommitteeMembersDirectory } from "@/lib/api/committee-member";
 import { listProjectRegistrationForms } from "@/lib/api/committee-project-registration-form";
 import { useAuthStore } from "@/lib/auth";
 import {
@@ -47,7 +47,7 @@ export const Route = createFileRoute("/committee/project-registration/")({
 	loader: async (): Promise<LoaderData> => {
 		const [{ forms }, { committeeMembers }] = await Promise.all([
 			listProjectRegistrationForms(),
-			listCommitteeMembers(),
+			listCommitteeMembersDirectory(),
 		]);
 
 		const currentUserId = useAuthStore.getState().user?.id;

--- a/apps/web/src/routes/committee/support/$inquiryId.tsx
+++ b/apps/web/src/routes/committee/support/$inquiryId.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/api/committee-inquiry";
 import {
 	getMyPermissions,
-	listCommitteeMembers,
+	listCommitteeMembersDirectory,
 } from "@/lib/api/committee-member";
 import { listCommitteeProjectMembers } from "@/lib/api/committee-project";
 import { useAuthStore } from "@/lib/auth";
@@ -40,7 +40,7 @@ export const Route = createFileRoute("/committee/support/$inquiryId")({
 		const { committeeMember } = useAuthStore.getState();
 		const inquiryRes = await getCommitteeInquiry(params.inquiryId);
 		const [membersRes, projectMembersRes, formsRes] = await Promise.all([
-			listCommitteeMembers(),
+			listCommitteeMembersDirectory(),
 			listCommitteeProjectMembers(inquiryRes.inquiry.projectId),
 			listMyForms(),
 		]);

--- a/apps/web/src/routes/committee/support/$inquiryId.tsx
+++ b/apps/web/src/routes/committee/support/$inquiryId.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/api/committee-inquiry";
 import {
 	getMyPermissions,
-	listCommitteeMembersDirectory,
+	listCommitteeMembersPicker,
 } from "@/lib/api/committee-member";
 import { listCommitteeProjectMembers } from "@/lib/api/committee-project";
 import { useAuthStore } from "@/lib/auth";
@@ -40,7 +40,7 @@ export const Route = createFileRoute("/committee/support/$inquiryId")({
 		const { committeeMember } = useAuthStore.getState();
 		const inquiryRes = await getCommitteeInquiry(params.inquiryId);
 		const [membersRes, projectMembersRes, formsRes] = await Promise.all([
-			listCommitteeMembersDirectory(),
+			listCommitteeMembersPicker(),
 			listCommitteeProjectMembers(inquiryRes.inquiry.projectId),
 			listMyForms(),
 		]);

--- a/apps/web/src/routes/committee/support/index.tsx
+++ b/apps/web/src/routes/committee/support/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/api/committee-inquiry";
 import {
 	getMyPermissions,
-	listCommitteeMembersDirectory,
+	listCommitteeMembersPicker,
 } from "@/lib/api/committee-member";
 import {
 	listCommitteeProjectMembers,
@@ -42,7 +42,7 @@ export const Route = createFileRoute("/committee/support/")({
 			[
 				listCommitteeInquiries(),
 				listCommitteeProjects(),
-				listCommitteeMembersDirectory(),
+				listCommitteeMembersPicker(),
 				listMyForms(),
 			]
 		);

--- a/apps/web/src/routes/committee/support/index.tsx
+++ b/apps/web/src/routes/committee/support/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/api/committee-inquiry";
 import {
 	getMyPermissions,
-	listCommitteeMembers,
+	listCommitteeMembersDirectory,
 } from "@/lib/api/committee-member";
 import {
 	listCommitteeProjectMembers,
@@ -42,7 +42,7 @@ export const Route = createFileRoute("/committee/support/")({
 			[
 				listCommitteeInquiries(),
 				listCommitteeProjects(),
-				listCommitteeMembers(),
+				listCommitteeMembersDirectory(),
 				listMyForms(),
 			]
 		);

--- a/packages/shared/src/endpoints/committee-member.ts
+++ b/packages/shared/src/endpoints/committee-member.ts
@@ -7,6 +7,7 @@ import {
 	grantCommitteeMemberPermissionRequestSchema,
 	grantCommitteeMemberPermissionResponseSchema,
 	listCommitteeMemberPermissionsResponseSchema,
+	listCommitteeMembersDirectoryResponseSchema,
 	listCommitteeMembersResponseSchema,
 	revokeCommitteeMemberPermissionResponseSchema,
 	updateCommitteeMemberRequestSchema,
@@ -25,11 +26,14 @@ const committeeMemberPermissionPathParamsSchema = z.object({
 
 /**
  * GET /committee/members
- * 委員メンバー一覧を取得
+ * 委員メンバー一覧を取得（管理画面用・フル情報）
  *
- * - 認証 + 実委メンバー必須
+ * - 認証 + 実委メンバー + MEMBER_EDIT 権限必須
  * - deletedAt が null のメンバーのみ返す
- * - user 情報を含む
+ * - user 情報（email, telephoneNumber を含むフル User）を含む
+ *
+ * 候補者ピッカーなど MEMBER_EDIT を持たないユーザーが利用する場合は
+ * {@link listCommitteeMembersDirectoryEndpoint} を使うこと。
  */
 export const listCommitteeMembersEndpoint: GetEndpoint<
 	"/committee/members",
@@ -43,6 +47,29 @@ export const listCommitteeMembersEndpoint: GetEndpoint<
 	query: undefined,
 	request: undefined,
 	response: listCommitteeMembersResponseSchema,
+} as const;
+
+/**
+ * GET /committee/members/directory
+ * 候補者ピッカー用の委員メンバー一覧を取得
+ *
+ * - 認証 + 実委メンバー必須（MEMBER_EDIT 権限不要）
+ * - deletedAt が null のメンバーのみ返す
+ * - email / telephoneNumber などの個人情報は含まない
+ * - お知らせ／お問い合わせ／申請／企画登録などの担当者選択 UI で使用
+ */
+export const listCommitteeMembersDirectoryEndpoint: GetEndpoint<
+	"/committee/members/directory",
+	undefined,
+	undefined,
+	typeof listCommitteeMembersDirectoryResponseSchema
+> = {
+	method: "GET",
+	path: "/committee/members/directory",
+	pathParams: undefined,
+	query: undefined,
+	request: undefined,
+	response: listCommitteeMembersDirectoryResponseSchema,
 } as const;
 
 /**

--- a/packages/shared/src/endpoints/committee-member.ts
+++ b/packages/shared/src/endpoints/committee-member.ts
@@ -7,7 +7,7 @@ import {
 	grantCommitteeMemberPermissionRequestSchema,
 	grantCommitteeMemberPermissionResponseSchema,
 	listCommitteeMemberPermissionsResponseSchema,
-	listCommitteeMembersDirectoryResponseSchema,
+	listCommitteeMembersPickerResponseSchema,
 	listCommitteeMembersResponseSchema,
 	revokeCommitteeMemberPermissionResponseSchema,
 	updateCommitteeMemberRequestSchema,
@@ -33,7 +33,7 @@ const committeeMemberPermissionPathParamsSchema = z.object({
  * - user 情報（email, telephoneNumber を含むフル User）を含む
  *
  * 候補者ピッカーなど MEMBER_EDIT を持たないユーザーが利用する場合は
- * {@link listCommitteeMembersDirectoryEndpoint} を使うこと。
+ * {@link listCommitteeMembersPickerEndpoint} を使うこと。
  */
 export const listCommitteeMembersEndpoint: GetEndpoint<
 	"/committee/members",
@@ -50,7 +50,7 @@ export const listCommitteeMembersEndpoint: GetEndpoint<
 } as const;
 
 /**
- * GET /committee/members/directory
+ * GET /committee/members/picker
  * 候補者ピッカー用の委員メンバー一覧を取得
  *
  * - 認証 + 実委メンバー必須（MEMBER_EDIT 権限不要）
@@ -58,18 +58,18 @@ export const listCommitteeMembersEndpoint: GetEndpoint<
  * - email / telephoneNumber などの個人情報は含まない
  * - お知らせ／お問い合わせ／申請／企画登録などの担当者選択 UI で使用
  */
-export const listCommitteeMembersDirectoryEndpoint: GetEndpoint<
-	"/committee/members/directory",
+export const listCommitteeMembersPickerEndpoint: GetEndpoint<
+	"/committee/members/picker",
 	undefined,
 	undefined,
-	typeof listCommitteeMembersDirectoryResponseSchema
+	typeof listCommitteeMembersPickerResponseSchema
 > = {
 	method: "GET",
-	path: "/committee/members/directory",
+	path: "/committee/members/picker",
 	pathParams: undefined,
 	query: undefined,
 	request: undefined,
-	response: listCommitteeMembersDirectoryResponseSchema,
+	response: listCommitteeMembersPickerResponseSchema,
 } as const;
 
 /**

--- a/packages/shared/src/schemas/committee-member.ts
+++ b/packages/shared/src/schemas/committee-member.ts
@@ -80,7 +80,7 @@ export type CommitteeMemberPermission = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
-// GET /committee-members
+// GET /committee/members
 // ─────────────────────────────────────────────────────────────
 
 /**

--- a/packages/shared/src/schemas/committee-member.ts
+++ b/packages/shared/src/schemas/committee-member.ts
@@ -100,6 +100,45 @@ export type ListCommitteeMembersResponse = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
+// GET /committee/members/directory
+// 候補者ピッカー用の最小情報のみを返すエンドポイント
+// （email / telephoneNumber などの個人情報は含まない）
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * 候補者ピッカー用の委員メンバーエントリ
+ *
+ * - user は { id, name, avatarFileId } のみ
+ * - permissions は { permission } のみ（NOTICE_DELIVER / FORM_DELIVER などの抽出に必要）
+ */
+export const committeeMemberDirectoryEntrySchema = z.object({
+	id: z.cuid(),
+	userId: z.string().min(1),
+	isExecutive: z.boolean(),
+	Bureau: bureauSchema,
+	user: userSchema.pick({
+		id: true,
+		name: true,
+		avatarFileId: true,
+	}),
+	permissions: z.array(
+		z.object({
+			permission: committeePermissionSchema,
+		})
+	),
+});
+export type CommitteeMemberDirectoryEntry = z.infer<
+	typeof committeeMemberDirectoryEntrySchema
+>;
+
+export const listCommitteeMembersDirectoryResponseSchema = z.object({
+	committeeMembers: z.array(committeeMemberDirectoryEntrySchema),
+});
+export type ListCommitteeMembersDirectoryResponse = z.infer<
+	typeof listCommitteeMembersDirectoryResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────
 // POST /committee-members
 // ─────────────────────────────────────────────────────────────
 

--- a/packages/shared/src/schemas/committee-member.ts
+++ b/packages/shared/src/schemas/committee-member.ts
@@ -100,7 +100,7 @@ export type ListCommitteeMembersResponse = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
-// GET /committee/members/directory
+// GET /committee/members/picker
 // 候補者ピッカー用の最小情報のみを返すエンドポイント
 // （email / telephoneNumber などの個人情報は含まない）
 // ─────────────────────────────────────────────────────────────
@@ -111,7 +111,7 @@ export type ListCommitteeMembersResponse = z.infer<
  * - user は { id, name, avatarFileId } のみ
  * - permissions は { permission } のみ（NOTICE_DELIVER / FORM_DELIVER などの抽出に必要）
  */
-export const committeeMemberDirectoryEntrySchema = z.object({
+export const committeeMemberPickerEntrySchema = z.object({
 	id: z.cuid(),
 	userId: z.string().min(1),
 	isExecutive: z.boolean(),
@@ -127,15 +127,15 @@ export const committeeMemberDirectoryEntrySchema = z.object({
 		})
 	),
 });
-export type CommitteeMemberDirectoryEntry = z.infer<
-	typeof committeeMemberDirectoryEntrySchema
+export type CommitteeMemberPickerEntry = z.infer<
+	typeof committeeMemberPickerEntrySchema
 >;
 
-export const listCommitteeMembersDirectoryResponseSchema = z.object({
-	committeeMembers: z.array(committeeMemberDirectoryEntrySchema),
+export const listCommitteeMembersPickerResponseSchema = z.object({
+	committeeMembers: z.array(committeeMemberPickerEntrySchema),
 });
-export type ListCommitteeMembersDirectoryResponse = z.infer<
-	typeof listCommitteeMembersDirectoryResponseSchema
+export type ListCommitteeMembersPickerResponse = z.infer<
+	typeof listCommitteeMembersPickerResponseSchema
 >;
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/shared/src/schemas/committee-member.ts
+++ b/packages/shared/src/schemas/committee-member.ts
@@ -139,7 +139,7 @@ export type ListCommitteeMembersDirectoryResponse = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
-// POST /committee-members
+// POST /committee/members
 // ─────────────────────────────────────────────────────────────
 
 /**
@@ -165,7 +165,7 @@ export type CreateCommitteeMemberResponse = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
-// PATCH /committee-members/:id
+// PATCH /committee/members/:id
 // ─────────────────────────────────────────────────────────────
 
 /**
@@ -190,7 +190,7 @@ export type UpdateCommitteeMemberResponse = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────
-// DELETE /committee-members/:id
+// DELETE /committee/members/:id
 // ─────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Summary

  - GET /committee/members に MEMBER_EDIT 権限チェックを追加（個人情報を含むフル情報は権限保持者のみ）
  - 候補者ピッカー用に GET /committee/members/directory を新設（実委メンバーなら取得可・最小情報のみ）
  - ピッカー利用箇所（forms / notice / project-registration / support / mastersheet）を新エンドポイントに切り替え
  - メンバー管理画面の権限判定をサーバー応答ベース（FORBIDDEN → ForbiddenError）に変更
  - 関連テスト追加

  Test plan

  - MEMBER_EDIT 非保持者でも各担当者ピッカーが動作
  - 同ユーザーで /committee/members は 403
  - MEMBER_EDIT 保持者では従来通りフル情報が表示