### PR TITLE
実委お知らせリンクを企画側で開けるようにする

### DIFF
--- a/apps/web/src/routes/committee/route.tsx
+++ b/apps/web/src/routes/committee/route.tsx
@@ -9,7 +9,6 @@ import {
 	requireCommitteeMember,
 	useAuthStore,
 } from "@/lib/auth";
-import { useProjectStore } from "@/lib/project/store";
 import styles from "./route.module.scss";
 
 // /committee/notice/{noticeId}/ から noticeId を抽出する
@@ -34,13 +33,9 @@ export const Route = createFileRoute("/committee")({
 		const { isCommitteeMember } = useAuthStore.getState();
 		if (!isCommitteeMember && isCommitteeNoticePath(location.pathname)) {
 			const noticeId = extractNoticeIdFromPath(location.pathname);
-			const { selectedProjectId } = useProjectStore.getState();
 			throw redirect({
 				to: "/project/notice",
-				search: {
-					...(selectedProjectId ? { projectId: selectedProjectId } : {}),
-					...(noticeId ? { noticeId } : {}),
-				},
+				search: noticeId ? { noticeId } : {},
 			});
 		}
 

--- a/apps/web/src/routes/committee/route.tsx
+++ b/apps/web/src/routes/committee/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 import { ForbiddenErrorBoundary } from "@/components/layout/ForbiddenContent";
 import { committeeMenuItems, Sidebar } from "@/components/layout/Sidebar";
@@ -11,9 +11,34 @@ import {
 } from "@/lib/auth";
 import styles from "./route.module.scss";
 
+// /committee/notice/{noticeId}/ から noticeId を抽出する
+function extractNoticeIdFromPath(pathname: string): string | undefined {
+	const match = pathname.match(/^\/committee\/notice\/([^/]+)/);
+	return match?.[1];
+}
+
+function isCommitteeNoticePath(pathname: string): boolean {
+	return (
+		pathname === "/committee/notice" ||
+		pathname.startsWith("/committee/notice/")
+	);
+}
+
 export const Route = createFileRoute("/committee")({
 	beforeLoad: async ({ location }) => {
 		await requireAuth(location.pathname);
+
+		// 実委人でない場合、/committee/notice* は /project/notice に振り替える
+		// (お知らせメールから企画者が踏んできた場合の救済)
+		const { isCommitteeMember } = useAuthStore.getState();
+		if (!isCommitteeMember && isCommitteeNoticePath(location.pathname)) {
+			const noticeId = extractNoticeIdFromPath(location.pathname);
+			throw redirect({
+				to: "/project/notice",
+				search: noticeId ? { noticeId } : {},
+			});
+		}
+
 		await requireCommitteeMember();
 		useAuthStore.getState().setActivePortal("committee");
 		await preloadMemberEditPermission();

--- a/apps/web/src/routes/committee/route.tsx
+++ b/apps/web/src/routes/committee/route.tsx
@@ -9,6 +9,7 @@ import {
 	requireCommitteeMember,
 	useAuthStore,
 } from "@/lib/auth";
+import { useProjectStore } from "@/lib/project/store";
 import styles from "./route.module.scss";
 
 // /committee/notice/{noticeId}/ から noticeId を抽出する
@@ -33,9 +34,13 @@ export const Route = createFileRoute("/committee")({
 		const { isCommitteeMember } = useAuthStore.getState();
 		if (!isCommitteeMember && isCommitteeNoticePath(location.pathname)) {
 			const noticeId = extractNoticeIdFromPath(location.pathname);
+			const { selectedProjectId } = useProjectStore.getState();
 			throw redirect({
 				to: "/project/notice",
-				search: noticeId ? { noticeId } : {},
+				search: {
+					...(selectedProjectId ? { projectId: selectedProjectId } : {}),
+					...(noticeId ? { noticeId } : {}),
+				},
 			});
 		}
 

--- a/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
+++ b/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
@@ -34,7 +34,7 @@ export function NoticeDetailDialog({
 	const [isLoading, setIsLoading] = useState(false);
 
 	useEffect(() => {
-		if (!noticeId) return;
+		if (!noticeId || !projectId) return;
 		let cancelled = false;
 		setIsLoading(true);
 

--- a/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
+++ b/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
@@ -20,7 +20,7 @@ const getBureauLabel = (bureau: string): string =>
 
 type Props = {
 	noticeId: string | null;
-	projectId: string;
+	projectId: string | null;
 	initialNotice?: GetProjectNoticeResponse["notice"] | null;
 	onClose: () => void;
 	onRead: (noticeId: string) => void;

--- a/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
+++ b/apps/web/src/routes/project/notice/-components/NoticeDetailDialog.tsx
@@ -1,5 +1,9 @@
 import { Dialog, Text } from "@radix-ui/themes";
-import type { Bureau, NoticeAttachment } from "@sos26/shared";
+import type {
+	Bureau,
+	GetProjectNoticeResponse,
+	NoticeAttachment,
+} from "@sos26/shared";
 import { bureauLabelMap } from "@sos26/shared";
 import { IconPaperclip } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
@@ -17,6 +21,7 @@ const getBureauLabel = (bureau: string): string =>
 type Props = {
 	noticeId: string | null;
 	projectId: string;
+	initialNotice?: GetProjectNoticeResponse["notice"] | null;
 	onClose: () => void;
 	onRead: (noticeId: string) => void;
 };
@@ -24,6 +29,7 @@ type Props = {
 export function NoticeDetailDialog({
 	noticeId,
 	projectId,
+	initialNotice,
 	onClose,
 	onRead,
 }: Props) {
@@ -36,23 +42,36 @@ export function NoticeDetailDialog({
 	useEffect(() => {
 		if (!noticeId || !projectId) return;
 		let cancelled = false;
+
+		const applyNotice = (notice: GetProjectNoticeResponse["notice"]) => {
+			setTitle(notice.title);
+			setBody(notice.body);
+			setMeta(
+				`${formatDate(new Date(notice.deliveredAt), "datetime")} ${getBureauLabel(notice.ownerBureau)}`
+			);
+			setAttachments(notice.attachments);
+
+			if (!notice.isRead) {
+				readProjectNotice(projectId, notice.id).then(() => {
+					if (!cancelled) onRead(notice.id);
+				});
+			}
+		};
+
+		if (initialNotice?.id === noticeId) {
+			applyNotice(initialNotice);
+			setIsLoading(false);
+			return () => {
+				cancelled = true;
+			};
+		}
+
 		setIsLoading(true);
 
 		getProjectNotice(projectId, noticeId)
 			.then(res => {
 				if (cancelled) return;
-				setTitle(res.notice.title);
-				setBody(res.notice.body);
-				setMeta(
-					`${formatDate(new Date(res.notice.deliveredAt), "datetime")}　${getBureauLabel(res.notice.ownerBureau)}`
-				);
-				setAttachments(res.notice.attachments);
-
-				if (!res.notice.isRead) {
-					readProjectNotice(projectId, noticeId).then(() => {
-						if (!cancelled) onRead(noticeId);
-					});
-				}
+				applyNotice(res.notice);
 			})
 			.catch(() => {
 				if (!cancelled) toast.error("お知らせの取得に失敗しました");
@@ -64,7 +83,7 @@ export function NoticeDetailDialog({
 		return () => {
 			cancelled = true;
 		};
-	}, [noticeId, projectId, onRead]);
+	}, [noticeId, projectId, initialNotice, onRead]);
 
 	const sanitizedBody = useMemo(
 		() => (body ? sanitizeHtml(body) : null),

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -16,12 +16,10 @@ import { Button } from "@/components/primitives";
 import { getProjectNotice, listProjectNotices } from "@/lib/api/project-notice";
 import { isClientError } from "@/lib/http/error";
 import { useProjectStore } from "@/lib/project/store";
-import { syncSelectedProjectFromSearch } from "@/lib/project/sync";
 import { NoticeDetailDialog } from "./-components/NoticeDetailDialog";
 import styles from "./index.module.scss";
 
 const searchSchema = z.object({
-	projectId: z.string().optional(),
 	noticeId: z.string().optional(),
 });
 
@@ -98,9 +96,6 @@ export const Route = createFileRoute("/project/notice/")({
 		meta: [{ title: "お知らせ | 雙峰祭オンラインシステム" }],
 	}),
 	validateSearch: searchSchema,
-	beforeLoad: ({ search }) => {
-		syncSelectedProjectFromSearch(search.projectId);
-	},
 	loader: async () => {
 		const { selectedProjectId } = useProjectStore.getState();
 		if (!selectedProjectId) return { notices: [] as NoticeRow[] };
@@ -150,8 +145,7 @@ function RouteComponent() {
 		}
 
 		const controller = new AbortController();
-		const preferredProjectId =
-			search.projectId ?? selectedProjectId ?? undefined;
+		const preferredProjectId = selectedProjectId ?? undefined;
 		void resolveNoticeProject(
 			targetNoticeId,
 			preferredProjectId,
@@ -164,10 +158,7 @@ function RouteComponent() {
 						useProjectStore.getState().setSelectedProjectId(result.projectId);
 						navigate({
 							to: "/project/notice",
-							search: {
-								projectId: result.projectId,
-								noticeId: targetNoticeId,
-							},
+							search: { noticeId: targetNoticeId },
 							replace: true,
 						});
 						return;
@@ -188,7 +179,7 @@ function RouteComponent() {
 			});
 
 		return () => controller.abort();
-	}, [search.noticeId, search.projectId, selectedProjectId, navigate]);
+	}, [search.noticeId, selectedProjectId, navigate]);
 
 	const handleRead = useCallback(
 		(noticeId: string) => {
@@ -235,16 +226,11 @@ function RouteComponent() {
 				<Button
 					intent="secondary"
 					size="1"
-					onClick={() =>
-						navigate({
-							to: "/project/notice",
-							search: {
-								projectId: selectedProjectId ?? undefined,
-								noticeId: row.original.id,
-							},
-							replace: true,
-						})
-					}
+					onClick={() => {
+						setSelectedNoticeProjectId(selectedProjectId);
+						setSelectedNoticeId(row.original.id);
+						setPreloadedNotice(null);
+					}}
 				>
 					<IconEye size={16} />
 					お知らせを見る
@@ -289,11 +275,13 @@ function RouteComponent() {
 					setSelectedNoticeId(null);
 					setSelectedNoticeProjectId(null);
 					setPreloadedNotice(null);
-					navigate({
-						to: "/project/notice",
-						search: { projectId: selectedProjectId ?? undefined },
-						replace: true,
-					});
+					if (search.noticeId) {
+						navigate({
+							to: "/project/notice",
+							search: {},
+							replace: true,
+						});
+					}
 				}}
 				initialNotice={preloadedNotice}
 				onRead={handleRead}

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -303,7 +303,7 @@ function RouteComponent() {
 
 			<NoticeDetailDialog
 				noticeId={selectedNotice?.id ?? null}
-				projectId={selectedNotice?.projectId ?? ""}
+				projectId={selectedNotice?.projectId ?? null}
 				onClose={() => {
 					setSelectedNotice(null);
 					if (search.noticeId) {

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -1,14 +1,20 @@
 import { Badge, Heading, Text } from "@radix-ui/themes";
 import type { Bureau } from "@sos26/shared";
-import { bureauLabelMap } from "@sos26/shared";
+import { bureauLabelMap, ErrorCode } from "@sos26/shared";
 import { IconEye } from "@tabler/icons-react";
-import { createFileRoute, useRouter } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	useNavigate,
+	useRouter,
+} from "@tanstack/react-router";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { z } from "zod";
 import { DataTable, DateCell } from "@/components/patterns";
 import { Button } from "@/components/primitives";
-import { listProjectNotices } from "@/lib/api/project-notice";
+import { getProjectNotice, listProjectNotices } from "@/lib/api/project-notice";
+import { isClientError } from "@/lib/http/error";
 import { useProjectStore } from "@/lib/project/store";
 import { syncSelectedProjectFromSearch } from "@/lib/project/sync";
 import { NoticeDetailDialog } from "./-components/NoticeDetailDialog";
@@ -16,6 +22,7 @@ import styles from "./index.module.scss";
 
 const searchSchema = z.object({
 	projectId: z.string().optional(),
+	noticeId: z.string().optional(),
 });
 
 const getBureauLabel = (bureau: string): string =>
@@ -31,6 +38,33 @@ type NoticeRow = {
 };
 
 const noticeColumnHelper = createColumnHelper<NoticeRow>();
+
+function isNoticeUnavailableError(error: unknown): boolean {
+	return (
+		isClientError(error) &&
+		(error.code === ErrorCode.NOT_FOUND || error.code === ErrorCode.FORBIDDEN)
+	);
+}
+
+async function resolveNoticeAcrossProjects(
+	noticeId: string,
+	signal: AbortSignal
+): Promise<{ projectId: string } | null> {
+	const { projects } = useProjectStore.getState();
+	for (const project of projects) {
+		if (signal.aborted) return null;
+		try {
+			await getProjectNotice(project.id, noticeId);
+			return { projectId: project.id };
+		} catch (error) {
+			if (!isNoticeUnavailableError(error)) {
+				throw error;
+			}
+			// 次の企画で試行
+		}
+	}
+	return null;
+}
 
 export const Route = createFileRoute("/project/notice/")({
 	component: RouteComponent,
@@ -60,7 +94,9 @@ export const Route = createFileRoute("/project/notice/")({
 
 function RouteComponent() {
 	const { notices: initialNotices } = Route.useLoaderData();
+	const search = Route.useSearch();
 	const router = useRouter();
+	const navigate = useNavigate();
 	const [notices, setNotices] = useState<NoticeRow[]>(initialNotices);
 	const { selectedProjectId } = useProjectStore();
 
@@ -69,6 +105,53 @@ function RouteComponent() {
 	}, [initialNotices]);
 
 	const [selectedNoticeId, setSelectedNoticeId] = useState<string | null>(null);
+	const [selectedNoticeProjectId, setSelectedNoticeProjectId] = useState<
+		string | null
+	>(null);
+
+	// /committee/notice/{noticeId}/ から振り替えられた場合、所属企画を順に探して
+	// 該当のお知らせを自動でダイアログ表示する。
+	useEffect(() => {
+		const targetNoticeId = search.noticeId;
+		if (!targetNoticeId) {
+			setSelectedNoticeId(null);
+			setSelectedNoticeProjectId(null);
+			return;
+		}
+
+		const controller = new AbortController();
+		void resolveNoticeAcrossProjects(targetNoticeId, controller.signal)
+			.then(result => {
+				if (controller.signal.aborted) return;
+				if (result) {
+					if (selectedProjectId !== result.projectId) {
+						useProjectStore.getState().setSelectedProjectId(result.projectId);
+						navigate({
+							to: "/project/notice",
+							search: {
+								projectId: result.projectId,
+								noticeId: targetNoticeId,
+							},
+							replace: true,
+						});
+						return;
+					}
+
+					setSelectedNoticeProjectId(result.projectId);
+					setSelectedNoticeId(targetNoticeId);
+				} else {
+					toast.error("このお知らせを表示する権限がありません");
+					navigate({ to: "/project/notice", search: {}, replace: true });
+				}
+			})
+			.catch(() => {
+				if (controller.signal.aborted) return;
+				toast.error("お知らせの取得に失敗しました");
+				navigate({ to: "/project/notice", search: {}, replace: true });
+			});
+
+		return () => controller.abort();
+	}, [search.noticeId, selectedProjectId, navigate]);
 
 	const handleRead = useCallback(
 		(noticeId: string) => {
@@ -115,7 +198,16 @@ function RouteComponent() {
 				<Button
 					intent="secondary"
 					size="1"
-					onClick={() => setSelectedNoticeId(row.original.id)}
+					onClick={() =>
+						navigate({
+							to: "/project/notice",
+							search: {
+								projectId: selectedProjectId ?? undefined,
+								noticeId: row.original.id,
+							},
+							replace: true,
+						})
+					}
 				>
 					<IconEye size={16} />
 					お知らせを見る
@@ -155,8 +247,16 @@ function RouteComponent() {
 
 			<NoticeDetailDialog
 				noticeId={selectedNoticeId}
-				projectId={selectedProjectId ?? ""}
-				onClose={() => setSelectedNoticeId(null)}
+				projectId={selectedNoticeProjectId ?? ""}
+				onClose={() => {
+					setSelectedNoticeId(null);
+					setSelectedNoticeProjectId(null);
+					navigate({
+						to: "/project/notice",
+						search: { projectId: selectedProjectId ?? undefined },
+						replace: true,
+					});
+				}}
 				onRead={handleRead}
 			/>
 		</div>

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -38,6 +38,11 @@ type NoticeRow = {
 };
 type NoticeDetail = GetProjectNoticeResponse["notice"];
 type ResolvedNotice = { projectId: string; notice: NoticeDetail };
+type SelectedNotice = {
+	id: string;
+	projectId: string;
+	initialNotice: NoticeDetail | null;
+};
 
 const noticeColumnHelper = createColumnHelper<NoticeRow>();
 const resolvedNoticeCache = new Map<string, ResolvedNotice>();
@@ -47,6 +52,16 @@ function getResolvedNoticeCacheKey(
 	noticeId: string
 ): string {
 	return `${projectId}:${noticeId}`;
+}
+
+function markCachedNoticeRead(noticeId: string) {
+	for (const [key, resolved] of resolvedNoticeCache) {
+		if (resolved.notice.id !== noticeId || resolved.notice.isRead) continue;
+		resolvedNoticeCache.set(key, {
+			...resolved,
+			notice: { ...resolved.notice, isRead: true },
+		});
+	}
 }
 
 function isNoticeUnavailableError(error: unknown): boolean {
@@ -142,11 +157,7 @@ function RouteComponent() {
 		setNotices(initialNotices);
 	}, [initialNotices]);
 
-	const [selectedNoticeId, setSelectedNoticeId] = useState<string | null>(null);
-	const [selectedNoticeProjectId, setSelectedNoticeProjectId] = useState<
-		string | null
-	>(null);
-	const [preloadedNotice, setPreloadedNotice] = useState<NoticeDetail | null>(
+	const [selectedNotice, setSelectedNotice] = useState<SelectedNotice | null>(
 		null
 	);
 
@@ -155,9 +166,7 @@ function RouteComponent() {
 	useEffect(() => {
 		const targetNoticeId = search.noticeId;
 		if (!targetNoticeId) {
-			setSelectedNoticeId(null);
-			setSelectedNoticeProjectId(null);
-			setPreloadedNotice(null);
+			setSelectedNotice(null);
 			return;
 		}
 
@@ -182,9 +191,11 @@ function RouteComponent() {
 						return;
 					}
 
-					setSelectedNoticeProjectId(result.projectId);
-					setSelectedNoticeId(targetNoticeId);
-					setPreloadedNotice(result.notice);
+					setSelectedNotice({
+						id: targetNoticeId,
+						projectId: result.projectId,
+						initialNotice: result.notice,
+					});
 				} else {
 					toast.error("このお知らせを表示する権限がありません");
 					navigate({ to: "/project/notice", search: {}, replace: true });
@@ -204,6 +215,7 @@ function RouteComponent() {
 			setNotices(prev =>
 				prev.map(n => (n.id === noticeId ? { ...n, isRead: true } : n))
 			);
+			markCachedNoticeRead(noticeId);
 			void router.invalidate();
 		},
 		[router]
@@ -245,9 +257,12 @@ function RouteComponent() {
 					intent="secondary"
 					size="1"
 					onClick={() => {
-						setSelectedNoticeProjectId(selectedProjectId);
-						setSelectedNoticeId(row.original.id);
-						setPreloadedNotice(null);
+						if (!selectedProjectId) return;
+						setSelectedNotice({
+							id: row.original.id,
+							projectId: selectedProjectId,
+							initialNotice: null,
+						});
 					}}
 				>
 					<IconEye size={16} />
@@ -287,12 +302,10 @@ function RouteComponent() {
 			/>
 
 			<NoticeDetailDialog
-				noticeId={selectedNoticeId}
-				projectId={selectedNoticeProjectId ?? ""}
+				noticeId={selectedNotice?.id ?? null}
+				projectId={selectedNotice?.projectId ?? ""}
 				onClose={() => {
-					setSelectedNoticeId(null);
-					setSelectedNoticeProjectId(null);
-					setPreloadedNotice(null);
+					setSelectedNotice(null);
 					if (search.noticeId) {
 						navigate({
 							to: "/project/notice",
@@ -301,7 +314,7 @@ function RouteComponent() {
 						});
 					}
 				}}
-				initialNotice={preloadedNotice}
+				initialNotice={selectedNotice?.initialNotice ?? null}
 				onRead={handleRead}
 			/>
 		</div>

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -16,10 +16,12 @@ import { Button } from "@/components/primitives";
 import { getProjectNotice, listProjectNotices } from "@/lib/api/project-notice";
 import { isClientError } from "@/lib/http/error";
 import { useProjectStore } from "@/lib/project/store";
+import { syncSelectedProjectFromSearch } from "@/lib/project/sync";
 import { NoticeDetailDialog } from "./-components/NoticeDetailDialog";
 import styles from "./index.module.scss";
 
 const searchSchema = z.object({
+	projectId: z.string().optional(),
 	noticeId: z.string().optional(),
 });
 
@@ -108,6 +110,9 @@ export const Route = createFileRoute("/project/notice/")({
 		meta: [{ title: "お知らせ | 雙峰祭オンラインシステム" }],
 	}),
 	validateSearch: searchSchema,
+	beforeLoad: ({ search }) => {
+		syncSelectedProjectFromSearch(search.projectId);
+	},
 	loader: async () => {
 		const { selectedProjectId } = useProjectStore.getState();
 		if (!selectedProjectId) return { notices: [] as NoticeRow[] };
@@ -291,7 +296,7 @@ function RouteComponent() {
 					if (search.noticeId) {
 						navigate({
 							to: "/project/notice",
-							search: {},
+							search: { projectId: search.projectId },
 							replace: true,
 						});
 					}

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -35,8 +35,17 @@ type NoticeRow = {
 	isRead: boolean;
 };
 type NoticeDetail = GetProjectNoticeResponse["notice"];
+type ResolvedNotice = { projectId: string; notice: NoticeDetail };
 
 const noticeColumnHelper = createColumnHelper<NoticeRow>();
+const resolvedNoticeCache = new Map<string, ResolvedNotice>();
+
+function getResolvedNoticeCacheKey(
+	projectId: string,
+	noticeId: string
+): string {
+	return `${projectId}:${noticeId}`;
+}
 
 function isNoticeUnavailableError(error: unknown): boolean {
 	return (
@@ -45,15 +54,25 @@ function isNoticeUnavailableError(error: unknown): boolean {
 	);
 }
 
-async function tryResolveNoticeInProject(
+async function getNoticeDetailInProject(
 	projectId: string,
 	noticeId: string,
 	signal: AbortSignal
-): Promise<{ projectId: string; notice: NoticeDetail } | null> {
+): Promise<ResolvedNotice | null> {
 	if (signal.aborted) return null;
+	const cached = resolvedNoticeCache.get(
+		getResolvedNoticeCacheKey(projectId, noticeId)
+	);
+	if (cached) return cached;
+
 	try {
 		const { notice } = await getProjectNotice(projectId, noticeId);
-		return { projectId, notice };
+		const resolved = { projectId, notice };
+		resolvedNoticeCache.set(
+			getResolvedNoticeCacheKey(projectId, noticeId),
+			resolved
+		);
+		return resolved;
 	} catch (error) {
 		if (!isNoticeUnavailableError(error)) {
 			throw error;
@@ -65,27 +84,20 @@ async function tryResolveNoticeInProject(
 async function resolveNoticeProject(
 	noticeId: string,
 	preferredProjectId: string | undefined,
+	preferredNotices: NoticeRow[],
 	signal: AbortSignal
-): Promise<{ projectId: string; notice: NoticeDetail } | null> {
-	if (preferredProjectId) {
-		const preferredResult = await tryResolveNoticeInProject(
-			preferredProjectId,
-			noticeId,
-			signal
-		);
-		if (preferredResult) return preferredResult;
+): Promise<ResolvedNotice | null> {
+	if (preferredProjectId && preferredNotices.some(n => n.id === noticeId)) {
+		return getNoticeDetailInProject(preferredProjectId, noticeId, signal);
 	}
 
 	const { projects } = useProjectStore.getState();
 	for (const project of projects) {
 		if (project.id === preferredProjectId) continue;
 		if (signal.aborted) return null;
-		const result = await tryResolveNoticeInProject(
-			project.id,
-			noticeId,
-			signal
-		);
-		if (result) return result;
+		const { notices } = await listProjectNotices(project.id);
+		if (!notices.some(n => n.id === noticeId)) continue;
+		return getNoticeDetailInProject(project.id, noticeId, signal);
 	}
 	return null;
 }
@@ -149,6 +161,7 @@ function RouteComponent() {
 		void resolveNoticeProject(
 			targetNoticeId,
 			preferredProjectId,
+			initialNotices,
 			controller.signal
 		)
 			.then(result => {
@@ -179,7 +192,7 @@ function RouteComponent() {
 			});
 
 		return () => controller.abort();
-	}, [search.noticeId, selectedProjectId, navigate]);
+	}, [search.noticeId, selectedProjectId, navigate, initialNotices]);
 
 	const handleRead = useCallback(
 		(noticeId: string) => {

--- a/apps/web/src/routes/project/notice/index.tsx
+++ b/apps/web/src/routes/project/notice/index.tsx
@@ -1,5 +1,5 @@
 import { Badge, Heading, Text } from "@radix-ui/themes";
-import type { Bureau } from "@sos26/shared";
+import type { Bureau, GetProjectNoticeResponse } from "@sos26/shared";
 import { bureauLabelMap, ErrorCode } from "@sos26/shared";
 import { IconEye } from "@tabler/icons-react";
 import {
@@ -36,6 +36,7 @@ type NoticeRow = {
 	deliveredAt: Date;
 	isRead: boolean;
 };
+type NoticeDetail = GetProjectNoticeResponse["notice"];
 
 const noticeColumnHelper = createColumnHelper<NoticeRow>();
 
@@ -46,22 +47,47 @@ function isNoticeUnavailableError(error: unknown): boolean {
 	);
 }
 
-async function resolveNoticeAcrossProjects(
+async function tryResolveNoticeInProject(
+	projectId: string,
 	noticeId: string,
 	signal: AbortSignal
-): Promise<{ projectId: string } | null> {
+): Promise<{ projectId: string; notice: NoticeDetail } | null> {
+	if (signal.aborted) return null;
+	try {
+		const { notice } = await getProjectNotice(projectId, noticeId);
+		return { projectId, notice };
+	} catch (error) {
+		if (!isNoticeUnavailableError(error)) {
+			throw error;
+		}
+		return null;
+	}
+}
+
+async function resolveNoticeProject(
+	noticeId: string,
+	preferredProjectId: string | undefined,
+	signal: AbortSignal
+): Promise<{ projectId: string; notice: NoticeDetail } | null> {
+	if (preferredProjectId) {
+		const preferredResult = await tryResolveNoticeInProject(
+			preferredProjectId,
+			noticeId,
+			signal
+		);
+		if (preferredResult) return preferredResult;
+	}
+
 	const { projects } = useProjectStore.getState();
 	for (const project of projects) {
+		if (project.id === preferredProjectId) continue;
 		if (signal.aborted) return null;
-		try {
-			await getProjectNotice(project.id, noticeId);
-			return { projectId: project.id };
-		} catch (error) {
-			if (!isNoticeUnavailableError(error)) {
-				throw error;
-			}
-			// 次の企画で試行
-		}
+		const result = await tryResolveNoticeInProject(
+			project.id,
+			noticeId,
+			signal
+		);
+		if (result) return result;
 	}
 	return null;
 }
@@ -108,6 +134,9 @@ function RouteComponent() {
 	const [selectedNoticeProjectId, setSelectedNoticeProjectId] = useState<
 		string | null
 	>(null);
+	const [preloadedNotice, setPreloadedNotice] = useState<NoticeDetail | null>(
+		null
+	);
 
 	// /committee/notice/{noticeId}/ から振り替えられた場合、所属企画を順に探して
 	// 該当のお知らせを自動でダイアログ表示する。
@@ -116,11 +145,18 @@ function RouteComponent() {
 		if (!targetNoticeId) {
 			setSelectedNoticeId(null);
 			setSelectedNoticeProjectId(null);
+			setPreloadedNotice(null);
 			return;
 		}
 
 		const controller = new AbortController();
-		void resolveNoticeAcrossProjects(targetNoticeId, controller.signal)
+		const preferredProjectId =
+			search.projectId ?? selectedProjectId ?? undefined;
+		void resolveNoticeProject(
+			targetNoticeId,
+			preferredProjectId,
+			controller.signal
+		)
 			.then(result => {
 				if (controller.signal.aborted) return;
 				if (result) {
@@ -139,6 +175,7 @@ function RouteComponent() {
 
 					setSelectedNoticeProjectId(result.projectId);
 					setSelectedNoticeId(targetNoticeId);
+					setPreloadedNotice(result.notice);
 				} else {
 					toast.error("このお知らせを表示する権限がありません");
 					navigate({ to: "/project/notice", search: {}, replace: true });
@@ -151,7 +188,7 @@ function RouteComponent() {
 			});
 
 		return () => controller.abort();
-	}, [search.noticeId, selectedProjectId, navigate]);
+	}, [search.noticeId, search.projectId, selectedProjectId, navigate]);
 
 	const handleRead = useCallback(
 		(noticeId: string) => {
@@ -251,12 +288,14 @@ function RouteComponent() {
 				onClose={() => {
 					setSelectedNoticeId(null);
 					setSelectedNoticeProjectId(null);
+					setPreloadedNotice(null);
 					navigate({
 						to: "/project/notice",
 						search: { projectId: selectedProjectId ?? undefined },
 						replace: true,
 					});
 				}}
+				initialNotice={preloadedNotice}
 				onRead={handleRead}
 			/>
 		</div>


### PR DESCRIPTION
  ## 概要
  - 企画者が `/committee/notice/:noticeId` にアクセスした場合、`/project/notice?noticeId=...` へ振り替える
  - `noticeId` から閲覧可能な企画を解決し、該当のお知らせ詳細を自動表示する
  - 既存の `/project/notice?projectId=...` による企画切替は維持する

  ## 変更内容
  - お知らせ詳細の選択状態を `selectedNotice` に統合
  - 解決済みお知らせ詳細をキャッシュし、詳細取得の重複を削減
  - 既読化後にキャッシュ上の `isRead` も更新し、再表示時の不要な既読APIを抑制