### PR TITLE
fix: マスタ・シート カラム追加で，直接チェック・ボックスを触ると押せない問題

### DIFF
--- a/apps/web/src/routes/committee/mastersheet/-components/AddFormItemColumnsDialog.module.scss
+++ b/apps/web/src/routes/committee/mastersheet/-components/AddFormItemColumnsDialog.module.scss
@@ -109,6 +109,14 @@
 	}
 }
 
+.itemCheckbox {
+	cursor: pointer;
+}
+
+.itemCardDisabled .itemCheckbox {
+	cursor: not-allowed;
+}
+
 .itemInfo {
 	display: flex;
 	align-items: center;

--- a/apps/web/src/routes/committee/mastersheet/-components/AddFormItemColumnsDialog.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/AddFormItemColumnsDialog.tsx
@@ -149,10 +149,11 @@ export function AddFormItemColumnsDialog({
 				}}
 			>
 				<RadixCheckbox
+					className={styles.itemCheckbox}
 					size="2"
 					checked={alreadyAdded || selected}
 					disabled={alreadyAdded}
-					onCheckedChange={() => !alreadyAdded && toggleItem(item.id)}
+					tabIndex={-1}
 					aria-hidden="true"
 				/>
 				<div className={styles.itemInfo}>


### PR DESCRIPTION
Closes https://github.com/sohosai/sos26/issues/341

ボタンに余計なハンドラがあり，チェックはできているが，すぐ戻されるという事象でありました。