### PR TITLE
feat: フォームの入力制限をタブ化

### DIFF
--- a/apps/web/src/components/form/Builder/AnswerFieldEditor.module.scss
+++ b/apps/web/src/components/form/Builder/AnswerFieldEditor.module.scss
@@ -25,6 +25,33 @@
   border-radius: var(--radius-2);
 }
 
+.constraintHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 0;
+  color: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.constraintHeaderMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--gray-11);
+}
+
+.constraintBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
 .constraintRow {
 	padding: var(--space-3);
   display: grid;

--- a/apps/web/src/components/form/Builder/AnswerFieldEditor.tsx
+++ b/apps/web/src/components/form/Builder/AnswerFieldEditor.tsx
@@ -7,7 +7,13 @@ import type {
 	TextConstraints,
 } from "@sos26/shared";
 import { allowedMimeTypes, mimeTypeLabels } from "@sos26/shared";
-import { IconPlus, IconX } from "@tabler/icons-react";
+import {
+	IconChevronDown,
+	IconChevronUp,
+	IconPlus,
+	IconX,
+} from "@tabler/icons-react";
+import { useState } from "react";
 import { Button, IconButton, Select, TextField } from "@/components/primitives";
 import { FileUploadField } from "../EachField/FileUploadField";
 import { NumberField } from "../EachField/NumberField";
@@ -73,6 +79,8 @@ function TextConstraintEditor({
 	onUpdate,
 }: TextConstraintEditorProps) {
 	const textConstraints = pickTextConstraints(constraints);
+	const [open, setOpen] = useState(() => textConstraints !== null);
+	const hasConstraints = textConstraints !== null;
 
 	const update = (partial: Partial<TextConstraints>) => {
 		const next = { ...(textConstraints ?? {}), ...partial };
@@ -93,51 +101,78 @@ function TextConstraintEditor({
 
 	return (
 		<div className={styles.constraints}>
-			<Text size="2" weight="medium">
-				入力制約
-			</Text>
-			<div className={styles.constraintRow}>
-				<NumberField
-					label="最小文字数"
-					value={textConstraints?.minLength ?? null}
-					onChange={n => update({ minLength: n ?? undefined })}
-					placeholder="例: 10"
-					error={minMaxError}
-				/>
-				<NumberField
-					label="最大文字数"
-					value={textConstraints?.maxLength ?? null}
-					onChange={n => update({ maxLength: n ?? undefined })}
-					placeholder="例: 200"
-				/>
-			</div>
-			<div>
-				<Text as="label" size="2" weight="medium">
-					文字種制限
+			<button
+				type="button"
+				className={styles.constraintHeader}
+				aria-expanded={open}
+				onClick={() => setOpen(v => !v)}
+			>
+				<Text size="2" weight="medium">
+					入力制限（文字数/文字種など）
 				</Text>
-				<div className={styles.patternRow}>
-					<Select
-						options={PATTERN_OPTIONS}
-						value={textConstraints?.pattern ?? "none"}
-						onValueChange={v => {
-							update({
-								pattern:
-									v === "none" ? undefined : (v as TextConstraints["pattern"]),
-								customPattern:
-									v !== "custom" ? undefined : textConstraints?.customPattern,
-							});
-						}}
-						aria-label="文字種制限"
-					/>
+				<div className={styles.constraintHeaderMeta}>
+					{hasConstraints && (
+						<Text size="1" color="gray">
+							設定済み
+						</Text>
+					)}
+					{open ? (
+						<IconChevronUp size={16} stroke={1.5} />
+					) : (
+						<IconChevronDown size={16} stroke={1.5} />
+					)}
 				</div>
-			</div>
-			{textConstraints?.pattern === "custom" && (
-				<TextField
-					label="正規表現パターン"
-					value={textConstraints.customPattern ?? ""}
-					onChange={v => update({ customPattern: v })}
-					placeholder="例: ^[ぁ-んー]+$"
-				/>
+			</button>
+			{open && (
+				<div className={styles.constraintBody}>
+					<div className={styles.constraintRow}>
+						<NumberField
+							label="最小文字数"
+							value={textConstraints?.minLength ?? null}
+							onChange={n => update({ minLength: n ?? undefined })}
+							placeholder="例: 10"
+							error={minMaxError}
+						/>
+						<NumberField
+							label="最大文字数"
+							value={textConstraints?.maxLength ?? null}
+							onChange={n => update({ maxLength: n ?? undefined })}
+							placeholder="例: 200"
+						/>
+					</div>
+					<div>
+						<Text as="label" size="2" weight="medium">
+							文字種制限
+						</Text>
+						<div className={styles.patternRow}>
+							<Select
+								options={PATTERN_OPTIONS}
+								value={textConstraints?.pattern ?? "none"}
+								onValueChange={v => {
+									update({
+										pattern:
+											v === "none"
+												? undefined
+												: (v as TextConstraints["pattern"]),
+										customPattern:
+											v !== "custom"
+												? undefined
+												: textConstraints?.customPattern,
+									});
+								}}
+								aria-label="文字種制限"
+							/>
+						</div>
+					</div>
+					{textConstraints?.pattern === "custom" && (
+						<TextField
+							label="正規表現パターン"
+							value={textConstraints.customPattern ?? ""}
+							onChange={v => update({ customPattern: v })}
+							placeholder="例: ^[ぁ-んー]+$"
+						/>
+					)}
+				</div>
 			)}
 		</div>
 	);
@@ -155,6 +190,8 @@ function FileConstraintEditor({
 	onUpdate,
 }: FileConstraintEditorProps) {
 	const fileConstraints = pickFileConstraints(constraints);
+	const [open, setOpen] = useState(() => fileConstraints !== null);
+	const hasConstraints = fileConstraints !== null;
 
 	const update = (partial: Partial<FileConstraints>) => {
 		const next = { ...(fileConstraints ?? {}), ...partial };
@@ -198,61 +235,84 @@ function FileConstraintEditor({
 
 	return (
 		<div className={styles.constraints}>
-			<Text size="2" weight="medium">
-				添付制約
-			</Text>
-			<div className={styles.constraintRow}>
-				<NumberField
-					label="最小ファイル数"
-					value={fileConstraints?.minFiles ?? null}
-					onChange={n => update({ minFiles: n ?? undefined })}
-					placeholder="例: 1"
-					error={minMaxError ?? requiredMinFilesError}
-				/>
-				<NumberField
-					label="最大ファイル数"
-					value={fileConstraints?.maxFiles ?? null}
-					onChange={n => update({ maxFiles: n ?? undefined })}
-					placeholder="例: 5"
-				/>
-				<div className={styles.constraintMimeTypesField}>
-					<Text as="label" size="2" weight="medium">
-						許可するファイル形式
-					</Text>
-					<Text size="1" color="gray" mx="1">
-						未選択の場合はすべての形式が許可されます
-					</Text>
+			<button
+				type="button"
+				className={styles.constraintHeader}
+				aria-expanded={open}
+				onClick={() => setOpen(v => !v)}
+			>
+				<Text size="2" weight="medium">
+					添付制限（ファイル数/形式など）
+				</Text>
+				<div className={styles.constraintHeaderMeta}>
+					{hasConstraints && (
+						<Text size="1" color="gray">
+							設定済み
+						</Text>
+					)}
+					{open ? (
+						<IconChevronUp size={16} stroke={1.5} />
+					) : (
+						<IconChevronDown size={16} stroke={1.5} />
+					)}
+				</div>
+			</button>
+			{open && (
+				<div className={styles.constraintBody}>
 					<div className={styles.constraintRow}>
-						{allowedMimeTypes.map(mimeType => (
-							<Text
-								as="span"
-								size="2"
-								key={mimeType}
-								style={{
-									display: "inline-flex",
-									alignItems: "center",
-									gap: "4px",
-									cursor: "pointer",
-								}}
-								onClick={() =>
-									handleMimeTypeToggle(
-										mimeType,
-										!selectedMimeTypes.has(mimeType)
-									)
-								}
-							>
-								<RadixCheckbox
-									checked={selectedMimeTypes.has(mimeType)}
-									onCheckedChange={checked =>
-										handleMimeTypeToggle(mimeType, checked === true)
-									}
-								/>
-								{mimeTypeLabels[mimeType]}
+						<NumberField
+							label="最小ファイル数"
+							value={fileConstraints?.minFiles ?? null}
+							onChange={n => update({ minFiles: n ?? undefined })}
+							placeholder="例: 1"
+							error={minMaxError ?? requiredMinFilesError}
+						/>
+						<NumberField
+							label="最大ファイル数"
+							value={fileConstraints?.maxFiles ?? null}
+							onChange={n => update({ maxFiles: n ?? undefined })}
+							placeholder="例: 5"
+						/>
+						<div className={styles.constraintMimeTypesField}>
+							<Text as="label" size="2" weight="medium">
+								許可するファイル形式
 							</Text>
-						))}
+							<Text size="1" color="gray" mx="1">
+								未選択の場合はすべての形式が許可されます
+							</Text>
+							<div className={styles.constraintRow}>
+								{allowedMimeTypes.map(mimeType => (
+									<Text
+										as="span"
+										size="2"
+										key={mimeType}
+										style={{
+											display: "inline-flex",
+											alignItems: "center",
+											gap: "4px",
+											cursor: "pointer",
+										}}
+										onClick={() =>
+											handleMimeTypeToggle(
+												mimeType,
+												!selectedMimeTypes.has(mimeType)
+											)
+										}
+									>
+										<RadixCheckbox
+											checked={selectedMimeTypes.has(mimeType)}
+											onCheckedChange={checked =>
+												handleMimeTypeToggle(mimeType, checked === true)
+											}
+										/>
+										{mimeTypeLabels[mimeType]}
+									</Text>
+								))}
+							</div>
+						</div>
 					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/components/form/Builder/AnswerFieldEditor.tsx
+++ b/apps/web/src/components/form/Builder/AnswerFieldEditor.tsx
@@ -79,7 +79,7 @@ function TextConstraintEditor({
 	onUpdate,
 }: TextConstraintEditorProps) {
 	const textConstraints = pickTextConstraints(constraints);
-	const [open, setOpen] = useState(() => textConstraints !== null);
+	const [open, setOpen] = useState(true);
 	const hasConstraints = textConstraints !== null;
 
 	const update = (partial: Partial<TextConstraints>) => {
@@ -190,7 +190,7 @@ function FileConstraintEditor({
 	onUpdate,
 }: FileConstraintEditorProps) {
 	const fileConstraints = pickFileConstraints(constraints);
-	const [open, setOpen] = useState(() => fileConstraints !== null);
+	const [open, setOpen] = useState(true);
 	const hasConstraints = fileConstraints !== null;
 
 	const update = (partial: Partial<FileConstraints>) => {


### PR DESCRIPTION
Closes #406 

State を持たせ， button でトグルするようにして対応しました。

従来の「入力制約」や「添付制約」だとやや直感的ではなくなってしまったため，それぞれ以下のように変更しました。

<img width="730" height="188" alt="image" src="https://github.com/user-attachments/assets/f8b5ee94-224b-47b6-a1c8-9a229199c992" />


<img width="699" height="343" alt="image" src="https://github.com/user-attachments/assets/c555f2a7-9451-4f15-9dc3-0f539a1d586c" />

---

<img width="736" height="122" alt="image" src="https://github.com/user-attachments/assets/5af70341-5329-49cf-ba17-54446ac9e87c" />



<img width="699" height="554" alt="image" src="https://github.com/user-attachments/assets/30149c09-9e75-4782-a081-0c5b65d41fc6" />
