### PR TITLE
fix: setTimeout オーバーフローで申請の入力欄が disabled になる問題を修正

### DIFF
--- a/apps/web/src/routes/project/forms/-components/ProjectFormAnswerDialog.tsx
+++ b/apps/web/src/routes/project/forms/-components/ProjectFormAnswerDialog.tsx
@@ -60,6 +60,8 @@ export function ProjectFormAnswerDialog({
 		}
 
 		const ms = deadlineAt.getTime() - now.getTime();
+		// setTimeout は 32bit 符号付き整数で扱われるため、約24.85日を超えると即発火する
+		if (ms > 2_147_483_647) return;
 		const timer = setTimeout(() => setIsDeadlineExpired(true), ms);
 		return () => clearTimeout(timer);
 	}, [fetchState]);


### PR DESCRIPTION
## 概要

  回答期限の設定によって、企画者が申請を開いた瞬間に入力欄が disabled になり回答できなくなる不具合を修正。

  ## 原因

  `apps/web/src/routes/project/forms/-components/ProjectFormAnswerDialog.tsx` の締切タイマーが `setTimeout` を使用しているが、`setTimeout` の delay は **32bit 符号付き整数** (max
  `2,147,483,647ms` ≒ 約24.85日) で扱われる。これを超える値を渡すと **ToInt32 によるラップアラウンド** が発生し、想定外のタイミングでコールバックが発火する。

  ref: https://developer.mozilla.org/ja/docs/Web/API/Window/setTimeout#%E6%9C%80%E5%A4%A7%E3%81%AE%E5%BE%85%E3%81%A1%E6%99%82%E9%96%93%E6%99%82%E9%96%93

  具体的には `ms = deadlineAt - now` の値に応じて、約25日周期で「即発火する帯」と「数時間〜数十時間後に発火する帯」が交互に出現する:

  | 締切までの期間 | ToInt32 後の値 | 実際の発火タイミング |
  |---|---|---|
  | ~24.85日 | そのまま | 正常 |
  | 24.85日 〜 49.7日 | 負の値 | **即発火 (= bug 発現)** |
  | 49.7日 〜 74.6日 | 小さい正の値 | 数時間〜数十時間後 |
  | 74.6日 〜 99.5日 | 負の値 | **即発火** |
  | ... | ... | ... |

  bug が発現すると:

  1. `setIsDeadlineExpired(true)` が即実行される
  2. `disableSubmit = true`, `disableSaveDraft = true` になる
  3. `FormViewer` の input が `disabled={disableSubmit && disableSaveDraft}` で disabled になる

  ## 修正

  `ms` が 32bit 上限を超える場合は `setTimeout` を張らずに早期 return する。これにより上記のどの「帯」でもタイマーが暴発しない。

  ダイアログを24日以上開きっぱなしにする想定はないため、その間の締切到来は次回ダイアログを開いた時の初回チェック (`deadlineAt <= now`) でカバーされる。

  ## 再現手順

  1. 実委人で申請を作成、回答期限を **現在から26日〜49日後** (即発火する帯) に設定、「遅延提出を認める」を OFF にして配信・承認
  2. 企画者でログインし「回答する」をクリック
  3. ダイアログ表示直後から入力欄が disabled (修正前) / 正常に編集可能 (修正後)

  > [!NOTE]
  > 締切を 50日〜74日後に設定した場合は ToInt32 後の値が正になるため、ダイアログを開いた直後には bug が再現しません
  (数時間放置すれば発火します)。確実な再現には「26日〜49日後」の範囲を使ってください。

  ## Test plan

  - [ ] 締切なしの申請を開いて入力できる
  - [ ] 締切が25日以内の申請を開いて入力できる
  - [ ] 締切が25日〜49日後の申請を開いて入力できる ← 本修正対象 (即発火する帯)
  - [ ] 締切が50日〜74日後の申請を開いて入力できる ← 本修正対象 (遅延発火する帯)
  - [ ] 「遅延提出を認める」が ON の申請を開いて入力できる
  - [ ] 締切過ぎの申請は引き続き disabled になる