### PR TITLE
有効な企画のみに申請とお知らせの通知

### DIFF
--- a/apps/api/src/lib/notifications/helpers/filterActiveProjects.ts
+++ b/apps/api/src/lib/notifications/helpers/filterActiveProjects.ts
@@ -1,0 +1,15 @@
+import { prisma } from "../../prisma";
+
+export async function filterActiveProjectIds(
+	projectIds: string[]
+): Promise<string[]> {
+	const projects = await prisma.project.findMany({
+		where: {
+			id: { in: projectIds },
+			deletedAt: null,
+			deletionStatus: null,
+		},
+		select: { id: true },
+	});
+	return projects.map(p => p.id);
+}

--- a/apps/api/src/lib/notifications/notifyFormDelivered.ts
+++ b/apps/api/src/lib/notifications/notifyFormDelivered.ts
@@ -2,16 +2,20 @@ import { sendFormDeliveredEmail } from "../emails";
 import { env } from "../env";
 import { prisma } from "../prisma";
 import { sendFormDeliveredPush } from "../push";
+import { filterActiveProjectIds } from "./helpers/filterActiveProjects";
 
 export async function notifyFormDelivered(input: {
 	formTitle: string;
 	projectIds: string[];
 }): Promise<boolean> {
 	try {
+		const activeProjectIds = await filterActiveProjectIds(input.projectIds);
+		if (activeProjectIds.length === 0) return true;
+
 		// 対象企画ごとにメンバーを取得し、企画ごとに通知を送る
 		// 複数企画に同じユーザーが所属する場合は複数通知が届く（各企画ごとに対応が必要なため）
 		const projects = await prisma.project.findMany({
-			where: { id: { in: input.projectIds }, deletedAt: null },
+			where: { id: { in: activeProjectIds }, deletedAt: null },
 			select: {
 				id: true,
 				ownerId: true,

--- a/apps/api/src/lib/notifications/notifyNoticeDelivered.ts
+++ b/apps/api/src/lib/notifications/notifyNoticeDelivered.ts
@@ -2,6 +2,7 @@ import { sendNoticeDeliveredEmail } from "../emails";
 import { env } from "../env";
 import { prisma } from "../prisma";
 import { sendNoticeDeliveredPush } from "../push";
+import { filterActiveProjectIds } from "./helpers/filterActiveProjects";
 
 export async function notifyNoticeDelivered(input: {
 	noticeTitle: string;
@@ -9,10 +10,13 @@ export async function notifyNoticeDelivered(input: {
 	projectIds: string[];
 }): Promise<boolean> {
 	try {
+		const activeProjectIds = await filterActiveProjectIds(input.projectIds);
+		if (activeProjectIds.length === 0) return true;
+
 		// 対象企画ごとにメンバーを取得し、企画ごとに通知を送る
 		// 複数企画に同じユーザーが所属する場合は複数通知が届く（各企画ごとに既読化が必要なため）
 		const projects = await prisma.project.findMany({
-			where: { id: { in: input.projectIds }, deletedAt: null },
+			where: { id: { in: activeProjectIds }, deletedAt: null },
 			select: {
 				id: true,
 				ownerId: true,


### PR DESCRIPTION
## 概要

企画ステータスが有効（`deletionStatus: null`）な企画に対してのみ、申請・お知らせの配信通知を送信するようにしました。

制限したい通知が増えた場合は、filterActiveProjectIdsを使って企画をフィルタする