### PR TITLE
お問い合わせの「担当者未割当て」を赤色に

### DIFF
--- a/apps/web/src/components/support/SupportDetail.tsx
+++ b/apps/web/src/components/support/SupportDetail.tsx
@@ -480,7 +480,7 @@ function SupportSidebar({
 	) => Promise<void>;
 	onRemoveAssignee: (assigneeId: string, userId: string) => Promise<void>;
 	statusLabel: string;
-	statusColor: "orange" | "blue" | "green";
+	statusColor: "red" | "orange" | "blue" | "green";
 	StatusIcon: typeof IconCheck;
 	currentUserId: string;
 	onStartEditDraft: () => void;

--- a/apps/web/src/components/support/constants.ts
+++ b/apps/web/src/components/support/constants.ts
@@ -9,13 +9,13 @@ export const statusConfig: Record<
 	InquiryStatus,
 	{
 		label: string;
-		color: "orange" | "blue" | "green";
+		color: "red" | "blue" | "green";
 		icon: typeof IconAlertCircle;
 	}
 > = {
 	UNASSIGNED: {
 		label: "担当者未割り当て",
-		color: "orange",
+		color: "red",
 		icon: IconAlertCircle,
 	},
 	IN_PROGRESS: { label: "対応中", color: "blue", icon: IconMessageDots },


### PR DESCRIPTION
fix #141 お問い合わせの「担当者未割当て」を赤色にする

