### PR TITLE
カラム編集モーダルのヘッダーのレスポンシブ対応

### DIFF
--- a/apps/web/src/components/support/SupportDetail.tsx
+++ b/apps/web/src/components/support/SupportDetail.tsx
@@ -480,7 +480,7 @@ function SupportSidebar({
 	) => Promise<void>;
 	onRemoveAssignee: (assigneeId: string, userId: string) => Promise<void>;
 	statusLabel: string;
-	statusColor: "orange" | "blue" | "green";
+	statusColor: "red" | "orange" | "blue" | "green";
 	StatusIcon: typeof IconCheck;
 	currentUserId: string;
 	onStartEditDraft: () => void;

--- a/apps/web/src/components/support/constants.ts
+++ b/apps/web/src/components/support/constants.ts
@@ -9,13 +9,13 @@ export const statusConfig: Record<
 	InquiryStatus,
 	{
 		label: string;
-		color: "orange" | "blue" | "green";
+		color: "red" | "blue" | "green";
 		icon: typeof IconAlertCircle;
 	}
 > = {
 	UNASSIGNED: {
 		label: "担当者未割り当て",
-		color: "orange",
+		color: "red",
 		icon: IconAlertCircle,
 	},
 	IN_PROGRESS: { label: "対応中", color: "blue", icon: IconMessageDots },

--- a/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.module.scss
+++ b/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.module.scss
@@ -209,6 +209,27 @@
 	.ownerActions {
 		opacity: 1;
 	}
+	.cardName {
+		width:45%;
+	}
+	.cardRight {
+		width: 55%;
+	}
+	.visibilityRow {
+		min-width: 10rem;
+	}
+	.header {
+    align-items: flex-start;
+    flex-direction: column;
+	}
+	.headerActions{
+		margin-top: var(--space-2);
+		width: 100%
+	}
+	.columnCloseButton{
+		margin-left: auto;
+		margin-top: -75px;
+	}
 }
 
 .editForm {

--- a/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
+++ b/apps/web/src/routes/committee/mastersheet/-components/ColumnPanel.tsx
@@ -978,7 +978,7 @@ export function ColumnPanel({
 	return (
 		<>
 			<Dialog.Root open={open} onOpenChange={onOpenChange}>
-				<Dialog.Content maxWidth="800px" minHeight="560px">
+				<Dialog.Content maxWidth="800px" minHeight="560px" width="90vw">
 					<div className={styles.header}>
 						<Dialog.Title mb="0">カラム</Dialog.Title>
 						<div className={styles.headerActions}>
@@ -999,6 +999,7 @@ export function ColumnPanel({
 							<IconButton
 								aria-label="閉じる"
 								onClick={() => onOpenChange(false)}
+								className={styles.columnCloseButton}
 							>
 								<IconX size={16} />
 							</IconButton>


### PR DESCRIPTION
fix #366 カラム編集モーダルのヘッダーのレスポンシブ対応
<img width="1290" height="2796" alt="localhost_5173_committee_mastersheet(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/89234384-9c9a-4ac4-b2a9-df1122187692" />
